### PR TITLE
feat: kitchen display screen, menu editor, and order lifecycle API

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Monorepo for a custom takeaway point-of-sale platform with a React client and a 
 
 - `client/` - React + TypeScript + Vite frontend for the POS UI
 - `server/` - Express + SQLite backend, WebSocket transport, and hardware adapters
+- `kitchen/` - React kitchen display screen (KDS) — real-time Kanban board for the kitchen
 - `docs/` - project documentation and planning materials
 - `_legacy/` - legacy reference code retained for migration context
 
@@ -28,6 +29,7 @@ For production hardware support (USB printer and caller ID device), see `server/
 ```bash
 cd server && npm install
 cd ../client && npm install
+cd ../kitchen && npm install
 ```
 
 2. Configure environment files
@@ -57,11 +59,16 @@ npm run dev
 # terminal 2
 cd client
 npm run dev
+
+# terminal 3 (optional — kitchen display screen)
+cd kitchen
+npm run dev
 ```
 
 Default URLs:
 
 - Client: `http://localhost:5173`
+- Kitchen display: `http://localhost:5174`
 - Server API: `http://localhost:4000/api`
 - Server WebSocket: `ws://localhost:4000`
 
@@ -90,7 +97,32 @@ git config core.hooksPath .githooks
 
 This enables the repo pre-commit hook that runs Prettier on staged files before each commit.
 
+## New API endpoints (kitchen integration)
+
+Added as part of the kitchen display screen feature branch:
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/orders/active` | All non-complete/non-cancelled orders with live kitchen status |
+| `PATCH` | `/api/orders/:id/status` | Advance an order through the kitchen state machine |
+
+Valid statuses: `new → accepted → cooking → ready → complete / cancelled`
+
+### New WebSocket events
+
+| Event type | Payload |
+|------------|---------|
+| `order_created` | `{ orderId, order, archivedAt, status }` |
+| `order_status_changed` | `{ orderId, previousStatus, status, updatedAt }` |
+| `order_cancelled` | `{ orderId }` |
+| `order_eta_updated` | `{ orderId, estimatedReadyAt }` |
+
+The `WebSocketMessage` type in `client/src/types/index.ts` has been updated to include all four new event types alongside the existing `incoming_call` event.
+
+Migration `005_order_status.sql` adds the `order_status` table that backs these endpoints.
+
 ## Where To Go Next
 
 - Backend details: [server/README.md](server/README.md)
 - Frontend details: [client/README.md](client/README.md)
+- Kitchen display: [kitchen/README.md](kitchen/README.md)

--- a/client/src/api/client.ts
+++ b/client/src/api/client.ts
@@ -12,8 +12,8 @@ import type { FullOrder, ArchivedOrder, Customer, Address, ApiError } from "../t
 const API_BASE_URL = config.apiUrl;
 
 function adminAuthHeaders(): Record<string, string> {
-  if (!config.adminPassword) return {};
-  return { Authorization: `Bearer ${config.adminPassword}` };
+  if (!config.adminApiToken) return {};
+  return { Authorization: `Bearer ${config.adminApiToken}` };
 }
 
 function redactApiPath(path: string) {
@@ -101,10 +101,10 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
 
 export const apiClient = {
   // Orders
-  async submitOrder(order: FullOrder): Promise<{ orderId: number; printed: boolean }> {
+  async submitOrder(order: FullOrder, clientOrderId?: string): Promise<{ orderId: number; printed: boolean }> {
     return request("/orders/print", {
       method: "POST",
-      body: JSON.stringify({ order, payment: order.payment }),
+      body: JSON.stringify({ order, payment: order.payment, clientOrderId }),
     });
   },
 
@@ -148,6 +148,47 @@ export const apiClient = {
     return request(`/customers/${phone}/export`, {
       headers: adminAuthHeaders(),
     });
+  },
+
+  // Menu
+  async fetchMenu(): Promise<unknown[]> {
+    return request("/menu");
+  },
+
+  async createMenuItem(item: {
+    id: string;
+    nameEn: string;
+    nameZh?: string;
+    price?: number;
+    primaryCategory?: string;
+    primaryStation?: string | null;
+    primaryCookTime?: number | null;
+    secondaryStation?: string | null;
+    secondaryCookTime?: number | null;
+    portionCapacity?: number | null;
+  }): Promise<unknown> {
+    return request("/menu", { method: "POST", body: JSON.stringify(item) });
+  },
+
+  async updateMenuItem(
+    id: string,
+    updates: {
+      nameEn?: string;
+      nameZh?: string;
+      price?: number | null;
+      primaryCategory?: string;
+      primaryStation?: string | null;
+      primaryCookTime?: number | null;
+      secondaryStation?: string | null;
+      secondaryCookTime?: number | null;
+      portionCapacity?: number | null;
+    },
+  ): Promise<unknown> {
+    return request(`/menu/${id}`, { method: "PUT", body: JSON.stringify(updates) });
+  },
+
+  async deleteMenuItem(id: string): Promise<void> {
+    return request(`/menu/${id}`, { method: "DELETE" });
   },
 
   // Addresses

--- a/client/src/assets/menu.json
+++ b/client/src/assets/menu.json
@@ -523,7 +523,7 @@
     "id": "C4",
     "name": {
       "en": "Three Special Roast",
-      "zh": "三烧"      
+      "zh": "三烧"
     },
     "price": 6.6,
     "primaryCategory": "Special",
@@ -993,7 +993,7 @@
     "id": "T1",
     "name": {
       "en": "Chicken in Thai Curry",
-      "zh": "泰加喱鸡"    
+      "zh": "泰加喱鸡"
     },
     "primaryCategory": "Chicken",
     "secondaryCategory": "Thai-Curry",
@@ -2302,7 +2302,12 @@
     },
     "price": 6.2,
     "primaryCategory": "Chicken",
-    "secondaryCategory": "Chow Mein"
+    "secondaryCategory": "Chow Mein",
+    "primaryStation": "noodle_machine",
+    "primaryCookTime": 300,
+    "secondaryStation": "wet_wok",
+    "secondaryCookTime": 60,
+    "portionCapacity": 1
   },
   {
     "id": "192",
@@ -2708,7 +2713,10 @@
       "en": "Egg Fried Rice",
       "zh": "蛋炒饭"
     },
-    "primaryCategories": ["Btn 1", "Rice"],
+    "primaryCategories": [
+      "Btn 1",
+      "Rice"
+    ],
     "secondaryCategory": "Rice",
     "options": [
       {
@@ -2727,7 +2735,10 @@
       "en": "Boiled Rice",
       "zh": "白饭"
     },
-    "primaryCategories": ["Btn 1", "Rice"],
+    "primaryCategories": [
+      "Btn 1",
+      "Rice"
+    ],
     "secondaryCategory": "Rice",
     "options": [
       {
@@ -2746,7 +2757,10 @@
       "en": "Chips",
       "zh": "薯条"
     },
-    "primaryCategories": ["Btn 1", "Chips"],
+    "primaryCategories": [
+      "Btn 1",
+      "Chips"
+    ],
     "secondaryCategory": "English",
     "options": [
       {
@@ -2769,7 +2783,9 @@
       "en": "Fried Soft Noodles",
       "zh": "炒软面"
     },
-    "primaryCategories": ["Btn 1"],
+    "primaryCategories": [
+      "Btn 1"
+    ],
     "secondaryCategory": "Chow Mein",
     "options": [
       {
@@ -2789,7 +2805,10 @@
       "zh": "香肠薯条"
     },
     "price": 4.5,
-    "primaryCategories": ["Btn 1", "Chips"],
+    "primaryCategories": [
+      "Btn 1",
+      "Chips"
+    ],
     "secondaryCategory": "English"
   },
   {
@@ -2799,7 +2818,10 @@
       "zh": "鸡块(10)"
     },
     "price": 4.5,
-    "primaryCategories": ["Btn 1", "Chicken"],
+    "primaryCategories": [
+      "Btn 1",
+      "Chicken"
+    ],
     "secondaryCategory": "English"
   },
   {
@@ -2809,7 +2831,11 @@
       "zh": "鸡块薯条"
     },
     "price": 4.5,
-    "primaryCategories": ["Btn 1", "Chicken", "Chips"],
+    "primaryCategories": [
+      "Btn 1",
+      "Chicken",
+      "Chips"
+    ],
     "secondaryCategory": "English"
   },
   {
@@ -2819,7 +2845,10 @@
       "zh": "洋冲圈"
     },
     "price": 3,
-    "primaryCategories": ["Btn 1", "Veg"],
+    "primaryCategories": [
+      "Btn 1",
+      "Veg"
+    ],
     "secondaryCategory": "Starter"
   },
   {
@@ -2828,7 +2857,10 @@
       "en": "Prawn Crackers",
       "zh": "虾片"
     },
-    "primaryCategories": ["Btn 1", "Shrimp"],
+    "primaryCategories": [
+      "Btn 1",
+      "Shrimp"
+    ],
     "secondaryCategory": "Starter",
     "options": [
       {
@@ -2851,7 +2883,10 @@
       "en": "Sauce",
       "zh": "汁"
     },
-    "primaryCategories": ["Btn 1", "Special"],
+    "primaryCategories": [
+      "Btn 1",
+      "Special"
+    ],
     "secondaryCategory": "Chef's",
     "options": [
       {
@@ -2899,7 +2934,9 @@
       "zh": "炸Mars Bar"
     },
     "price": 3.2,
-    "primaryCategories": ["Special"],
+    "primaryCategories": [
+      "Special"
+    ],
     "secondaryCategory": "English"
   },
   {
@@ -2909,7 +2946,9 @@
       "zh": "炸蕉"
     },
     "price": 3.2,
-    "primaryCategories": ["Veg"],
+    "primaryCategories": [
+      "Veg"
+    ],
     "secondaryCategory": "English"
   },
   {
@@ -2919,7 +2958,9 @@
       "zh": "炸菠萝"
     },
     "price": 3.2,
-    "primaryCategories": ["Veg"],
+    "primaryCategories": [
+      "Veg"
+    ],
     "secondaryCategory": "English"
   },
   {
@@ -2928,7 +2969,9 @@
       "en": "Cans",
       "zh": "罐装"
     },
-    "primaryCategories": ["Btn 1"],
+    "primaryCategories": [
+      "Btn 1"
+    ],
     "secondaryCategory": "English",
     "options": [
       {
@@ -2964,7 +3007,9 @@
       "zh": "瓶装"
     },
     "price": 2.6,
-    "primaryCategories": ["Btn 1"],
+    "primaryCategories": [
+      "Btn 1"
+    ],
     "secondaryCategory": "English",
     "options": [
       {

--- a/client/src/components/layout/admin-page.tsx
+++ b/client/src/components/layout/admin-page.tsx
@@ -28,6 +28,7 @@ import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
 import { ScrollArea } from "../ui/scroll-area";
+import { MenuEditorTab } from "./menu-editor-tab";
 
 interface AdminPageProps {
   onClose: () => void;
@@ -44,6 +45,10 @@ function getAdminApiErrorMessage(err: unknown, fallback: string) {
   const apiErr = err as ApiLikeError;
   const code = apiErr?.code;
   const status = apiErr?.status;
+
+  if (code === "RATE_LIMITED" || status === 429) {
+    return "Too many failed admin token attempts. Wait a minute, then try again.";
+  }
 
   if (code === "ADMIN_AUTH_NOT_CONFIGURED" || status === 503) {
     return "Server admin auth is not configured. Set ADMIN_API_TOKEN on the server and restart.";
@@ -77,6 +82,7 @@ const ORDER_TYPE_BADGE_SOLID: Record<string, string> = {
 export function AdminPage({ onClose }: AdminPageProps) {
   // ─── Auth ────────────────────────────────────────────────────────────────
   const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const [activeTab, setActiveTab] = useState<"orders" | "menu">("orders");
   const [password, setPassword] = useState("");
   const [loginError, setLoginError] = useState("");
 
@@ -115,7 +121,12 @@ export function AdminPage({ onClose }: AdminPageProps) {
         setOrders(data.orders);
       } catch (err) {
         console.error("Failed to fetch orders", err);
-        setFetchError("Could not load orders for this date. Check your connection and try again.");
+        setFetchError(
+          getAdminApiErrorMessage(
+            err,
+            "Could not load orders for this date. Check your connection.",
+          ),
+        );
       } finally {
         setIsLoading(false);
       }
@@ -170,12 +181,18 @@ export function AdminPage({ onClose }: AdminPageProps) {
   };
 
   const handleLogin = () => {
-    if (!config.adminPassword) {
-      setLoginError("Admin PIN not configured");
+    if (config.adminTokenMismatch) {
+      setLoginError("Set only VITE_ADMIN_API_TOKEN (or make both keys identical)");
       setPassword("");
       return;
     }
-    if (password === config.adminPassword) {
+
+    if (!config.adminApiToken) {
+      setLoginError("Admin token not configured (VITE_ADMIN_API_TOKEN)");
+      setPassword("");
+      return;
+    }
+    if (password === config.adminApiToken) {
       setIsAuthenticated(true);
       setLoginError("");
     } else {
@@ -402,7 +419,7 @@ export function AdminPage({ onClose }: AdminPageProps) {
       className="fixed inset-0 z-[100] flex flex-col bg-zinc-950 text-white overflow-hidden p-4"
     >
       {/* Header */}
-      <header className="flex items-center justify-between mb-6">
+      <header className="flex items-center justify-between mb-4">
         <div className="flex items-center gap-4">
           <h1 className="text-3xl font-bold tracking-tight bg-gradient-to-r from-white to-zinc-500 bg-clip-text text-transparent italic">
             Admin Dashboard
@@ -416,6 +433,30 @@ export function AdminPage({ onClose }: AdminPageProps) {
           <X className="h-6 w-6" />
         </Button>
       </header>
+
+      {/* Tab bar */}
+      <div className="flex gap-1 mb-5 border-b border-zinc-800 shrink-0">
+        {(["orders", "menu"] as const).map((tab) => (
+          <button
+            key={tab}
+            onClick={() => setActiveTab(tab)}
+            className={cn(
+              "px-5 py-2 text-sm font-semibold tracking-wide uppercase transition-colors border-b-2 -mb-px",
+              activeTab === tab
+                ? "text-white border-sky-500"
+                : "text-zinc-500 border-transparent hover:text-zinc-300",
+            )}
+          >
+            {tab === "orders" ? "Orders" : "Menu Editor"}
+          </button>
+        ))}
+      </div>
+
+      {/* Menu editor tab — rendered outside the orders layout */}
+      {activeTab === "menu" && <MenuEditorTab />}
+
+      {/* Orders tab content */}
+      {activeTab === "orders" && <>
 
       {/* Controls */}
       <div className="grid grid-cols-1 md:grid-cols-4 gap-4 mb-6">
@@ -960,6 +1001,8 @@ export function AdminPage({ onClose }: AdminPageProps) {
           </div>
         )}
       </AnimatePresence>
+
+      </>}
     </motion.div>
   );
 }

--- a/client/src/components/layout/menu-editor-tab.tsx
+++ b/client/src/components/layout/menu-editor-tab.tsx
@@ -1,0 +1,563 @@
+import { useState, useEffect, useMemo, useCallback } from "react";
+import { Search, Check, Loader2, AlertCircle, Trash2, Plus, X } from "lucide-react";
+import { apiClient } from "../../api/client";
+
+// ---------------------------------------------------------------------------
+// Station config
+// ---------------------------------------------------------------------------
+
+const STATION_OPTIONS = [
+  { value: "dark_fryer",           label: "Dark Fryer" },
+  { value: "light_fryer",          label: "Light Fryer" },
+  { value: "oil_wok",              label: "Oil Wok" },
+  { value: "wet_wok",              label: "Wet Wok" },
+  { value: "noodle_machine",       label: "Noodle Machine" },
+  { value: "noodle_machine_spicy", label: "Noodle Machine (Spicy)" },
+  { value: "microwave",            label: "Microwave" },
+  { value: "boiler",               label: "Boiler" },
+  { value: "sauce",                label: "Sauce" },
+] as const;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface RawMenuItem {
+  id: string;
+  name: { en: string; zh?: string };
+  primaryCategory?: string;
+  price?: number;
+  primaryStation?: string;
+  primaryCookTime?: number;
+  secondaryStation?: string;
+  secondaryCookTime?: number;
+  portionCapacity?: number;
+  // set meal / legacy
+  contents?: unknown[];
+}
+
+interface MenuItemUpdates {
+  nameEn?: string;
+  nameZh?: string;
+  price?: number | null;
+  primaryCategory?: string;
+  primaryStation?: string | null;
+  primaryCookTime?: number | null;
+  secondaryStation?: string | null;
+  secondaryCookTime?: number | null;
+  portionCapacity?: number | null;
+}
+
+type SaveState = "idle" | "saving" | "saved" | "error";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function fmtSecs(s: number | undefined): string {
+  if (!s) return "";
+  const m = Math.floor(s / 60);
+  const r = s % 60;
+  if (m === 0) return `${r}s`;
+  return r === 0 ? `${m}m` : `${m}m ${r}s`;
+}
+
+function parsePosInt(v: string): number | null {
+  const n = parseInt(v, 10);
+  return Number.isFinite(n) && n > 0 ? n : null;
+}
+
+// ---------------------------------------------------------------------------
+// Add Item Modal
+// ---------------------------------------------------------------------------
+
+interface AddItemModalProps {
+  categories: string[];
+  onAdd: (item: RawMenuItem) => void;
+  onClose: () => void;
+}
+
+const EMPTY_FORM = {
+  id: "", nameEn: "", nameZh: "", price: "",
+  primaryCategory: "",
+  primaryStation: "", primaryCookTime: "",
+  secondaryStation: "", secondaryCookTime: "",
+  portionCapacity: "",
+};
+
+function AddItemModal({ categories, onAdd, onClose }: AddItemModalProps) {
+  const [form, setForm] = useState(EMPTY_FORM);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+
+  const set = (k: keyof typeof EMPTY_FORM) => (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) =>
+    setForm((p) => ({ ...p, [k]: e.target.value }));
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!form.id.trim() || !form.nameEn.trim()) {
+      setError("ID and English name are required.");
+      return;
+    }
+    setSaving(true);
+    setError("");
+    try {
+      const payload = {
+        id: form.id.trim().toUpperCase(),
+        nameEn: form.nameEn.trim(),
+        nameZh: form.nameZh.trim() || undefined,
+        price: form.price ? parseFloat(form.price) : undefined,
+        primaryCategory: form.primaryCategory || undefined,
+        primaryStation: form.primaryStation || null,
+        primaryCookTime: parsePosInt(form.primaryCookTime),
+        secondaryStation: form.secondaryStation || null,
+        secondaryCookTime: parsePosInt(form.secondaryCookTime),
+        portionCapacity: parsePosInt(form.portionCapacity),
+      };
+      await apiClient.createMenuItem(payload);
+      const newItem: RawMenuItem = {
+        id: payload.id,
+        name: { en: payload.nameEn, zh: payload.nameZh },
+        primaryCategory: payload.primaryCategory,
+        price: payload.price,
+        primaryStation: payload.primaryStation ?? undefined,
+        primaryCookTime: payload.primaryCookTime ?? undefined,
+        secondaryStation: payload.secondaryStation ?? undefined,
+        secondaryCookTime: payload.secondaryCookTime ?? undefined,
+        portionCapacity: payload.portionCapacity ?? undefined,
+      };
+      onAdd(newItem);
+      onClose();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Failed to create item.";
+      setError(msg.includes("already exists") ? `ID '${form.id.toUpperCase()}' is already in use.` : msg);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const inputCls = "w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2 text-sm text-white placeholder-zinc-600 focus:outline-none focus:border-sky-500";
+  const labelCls = "block text-[10px] uppercase tracking-widest text-zinc-500 font-semibold mb-1";
+  const selectCls = "w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-sky-500";
+
+  return (
+    <div className="fixed inset-0 z-[110] flex items-center justify-center p-4">
+      <div className="absolute inset-0 bg-black/70 backdrop-blur-sm" onClick={onClose} />
+      <div className="relative w-full max-w-xl bg-zinc-950 border border-zinc-800 rounded-2xl shadow-2xl overflow-hidden">
+        <div className="flex items-center justify-between px-6 py-4 border-b border-zinc-800">
+          <h2 className="text-lg font-bold text-white">Add Menu Item</h2>
+          <button onClick={onClose} className="text-zinc-500 hover:text-white transition-colors">
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="p-6 space-y-4 overflow-y-auto max-h-[75vh]">
+          {/* ID + Names */}
+          <div className="grid grid-cols-3 gap-3">
+            <div>
+              <label className={labelCls}>Item ID *</label>
+              <input placeholder="e.g. CM1" value={form.id} onChange={set("id")} className={inputCls} />
+            </div>
+            <div>
+              <label className={labelCls}>English Name *</label>
+              <input placeholder="Chicken Chow Mein" value={form.nameEn} onChange={set("nameEn")} className={inputCls} />
+            </div>
+            <div>
+              <label className={labelCls}>Chinese Name</label>
+              <input placeholder="鸡肉炒面" value={form.nameZh} onChange={set("nameZh")} className={inputCls} />
+            </div>
+          </div>
+
+          {/* Price + Category */}
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className={labelCls}>Price (£)</label>
+              <input type="number" min={0} step={0.01} placeholder="0.00" value={form.price} onChange={set("price")} className={inputCls} />
+            </div>
+            <div>
+              <label className={labelCls}>Category</label>
+              <select value={form.primaryCategory} onChange={set("primaryCategory")} className={selectCls}>
+                <option value="">— none —</option>
+                {categories.filter((c) => c !== "All").map((c) => (
+                  <option key={c} value={c}>{c}</option>
+                ))}
+              </select>
+            </div>
+          </div>
+
+          <div className="border-t border-zinc-800 pt-4">
+            <p className="text-[10px] uppercase tracking-widest text-zinc-500 font-semibold mb-3">Kitchen Timing</p>
+
+            {/* Primary station */}
+            <div className="flex gap-3 mb-3 items-end">
+              <div className="flex-1">
+                <label className={labelCls}>Primary station</label>
+                <select value={form.primaryStation} onChange={set("primaryStation")} className={selectCls}>
+                  <option value="">— none —</option>
+                  {STATION_OPTIONS.map((s) => <option key={s.value} value={s.value}>{s.label}</option>)}
+                </select>
+              </div>
+              <div className="w-28">
+                <label className={labelCls}>Time (seconds)</label>
+                <div className="flex items-center gap-1.5">
+                  <input type="number" min={0} placeholder="sec" value={form.primaryCookTime} onChange={set("primaryCookTime")}
+                    className="w-20 bg-zinc-800 border border-zinc-700 rounded-lg px-2 py-2 text-sm text-white text-right focus:outline-none focus:border-sky-500" />
+                  {form.primaryCookTime && (
+                    <span className="text-xs text-zinc-500 shrink-0">{fmtSecs(parsePosInt(form.primaryCookTime) ?? 0)}</span>
+                  )}
+                </div>
+              </div>
+            </div>
+
+            {/* Secondary station */}
+            <div className="flex gap-3 mb-3 items-end">
+              <div className="flex-1">
+                <label className={labelCls}>2nd station <span className="normal-case text-zinc-600">(optional)</span></label>
+                <select value={form.secondaryStation} onChange={set("secondaryStation")} className={selectCls}>
+                  <option value="">— none —</option>
+                  {STATION_OPTIONS.map((s) => <option key={s.value} value={s.value}>{s.label}</option>)}
+                </select>
+              </div>
+              <div className="w-28">
+                <label className={labelCls}>Time (seconds)</label>
+                <div className="flex items-center gap-1.5">
+                  <input type="number" min={0} placeholder="sec" value={form.secondaryCookTime} onChange={set("secondaryCookTime")}
+                    className="w-20 bg-zinc-800 border border-zinc-700 rounded-lg px-2 py-2 text-sm text-white text-right focus:outline-none focus:border-sky-500" />
+                  {form.secondaryCookTime && (
+                    <span className="text-xs text-zinc-500 shrink-0">{fmtSecs(parsePosInt(form.secondaryCookTime) ?? 0)}</span>
+                  )}
+                </div>
+              </div>
+            </div>
+
+            {/* Portions per run */}
+            <div className="w-40">
+              <label className={labelCls}>Portions per run</label>
+              <input type="number" min={1} placeholder="1" value={form.portionCapacity} onChange={set("portionCapacity")}
+                className="w-20 bg-zinc-800 border border-zinc-700 rounded-lg px-2 py-2 text-sm text-white text-right focus:outline-none focus:border-sky-500" />
+            </div>
+
+            {/* Total */}
+            {(form.primaryCookTime || form.secondaryCookTime) && (
+              <div className="mt-3 text-xs text-zinc-500">
+                Total cook time:{" "}
+                <span className="text-white font-semibold">
+                  {fmtSecs(
+                    (parsePosInt(form.primaryCookTime) ?? 0) +
+                    (parsePosInt(form.secondaryCookTime) ?? 0)
+                  )}
+                </span>
+              </div>
+            )}
+          </div>
+
+          {error && (
+            <div className="flex items-center gap-2 text-sm text-red-400 bg-red-400/10 border border-red-400/20 rounded-lg px-3 py-2">
+              <AlertCircle className="w-4 h-4 shrink-0" />
+              {error}
+            </div>
+          )}
+
+          <div className="flex gap-3 pt-2">
+            <button type="button" onClick={onClose}
+              className="flex-1 py-2 rounded-xl border border-zinc-700 text-zinc-400 hover:text-white hover:border-zinc-500 text-sm font-semibold transition-colors">
+              Cancel
+            </button>
+            <button type="submit" disabled={saving}
+              className="flex-1 py-2 rounded-xl bg-sky-600 hover:bg-sky-500 disabled:opacity-50 text-white text-sm font-semibold transition-colors flex items-center justify-center gap-2">
+              {saving ? <Loader2 className="w-4 h-4 animate-spin" /> : <Plus className="w-4 h-4" />}
+              Add Item
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Item row
+// ---------------------------------------------------------------------------
+
+interface RowProps {
+  item: RawMenuItem;
+  onSave: (id: string, updates: MenuItemUpdates) => Promise<void>;
+  onDelete: (id: string) => Promise<void>;
+}
+
+function MenuItemRow({ item, onSave, onDelete }: RowProps) {
+  const [primaryStation, setPrimaryStation]     = useState(item.primaryStation ?? "");
+  const [primaryCookTime, setPrimaryCookTime]   = useState(item.primaryCookTime?.toString() ?? "");
+  const [secondaryStation, setSecondaryStation] = useState(item.secondaryStation ?? "");
+  const [secondaryCookTime, setSecondaryCookTime] = useState(item.secondaryCookTime?.toString() ?? "");
+  const [portionCapacity, setPortionCapacity]   = useState(item.portionCapacity?.toString() ?? "");
+  const [saveState, setSaveState]               = useState<SaveState>("idle");
+  const [confirmDelete, setConfirmDelete]       = useState(false);
+
+  const isSetMeal = !!item.contents?.length;
+
+  const save = useCallback(async () => {
+    setSaveState("saving");
+    try {
+      await onSave(item.id, {
+        primaryStation:    primaryStation    || null,
+        primaryCookTime:   parsePosInt(primaryCookTime),
+        secondaryStation:  secondaryStation  || null,
+        secondaryCookTime: parsePosInt(secondaryCookTime),
+        portionCapacity:   parsePosInt(portionCapacity),
+      });
+      setSaveState("saved");
+      setTimeout(() => setSaveState("idle"), 1500);
+    } catch {
+      setSaveState("error");
+      setTimeout(() => setSaveState("idle"), 3000);
+    }
+  }, [item.id, primaryStation, primaryCookTime, secondaryStation, secondaryCookTime, portionCapacity, onSave]);
+
+  const handleDelete = async () => {
+    if (!confirmDelete) { setConfirmDelete(true); return; }
+    setSaveState("saving");
+    try {
+      await onDelete(item.id);
+    } catch {
+      setSaveState("error");
+      setTimeout(() => setSaveState("idle"), 3000);
+      setConfirmDelete(false);
+    }
+  };
+
+  const totalSecs =
+    (parsePosInt(primaryCookTime) ?? 0) + (parsePosInt(secondaryCookTime) ?? 0);
+
+  const selectCls =
+    "bg-zinc-900 border border-zinc-700 rounded-lg px-2 py-1.5 text-sm text-white focus:outline-none focus:border-sky-500 transition-colors";
+  const timeInputCls =
+    "w-16 bg-zinc-900 border border-zinc-700 rounded-lg px-2 py-1.5 text-sm text-white tabular-nums text-right focus:outline-none focus:border-sky-500 transition-colors";
+
+  return (
+    <div
+      className={`px-4 py-3 border-b border-zinc-800/60 hover:bg-zinc-900/40 transition-colors ${confirmDelete ? "bg-red-950/20" : ""}`}
+      onMouseLeave={() => setConfirmDelete(false)}
+    >
+      <div className="flex items-center gap-3">
+        {/* Name */}
+        <div className="w-44 shrink-0">
+          <div className="font-mono text-[10px] text-zinc-600 uppercase tracking-wider">{item.id}</div>
+          <div className="text-sm font-medium text-white truncate">{item.name.en}</div>
+          {item.name.zh && <div className="text-xs text-amber-400/60 truncate">{item.name.zh}</div>}
+          {isSetMeal && (
+            <div className="text-[10px] text-purple-400/70 mt-0.5">set meal</div>
+          )}
+        </div>
+
+        {/* Primary station + time */}
+        <div className="flex items-center gap-1.5 shrink-0">
+          <select value={primaryStation} onChange={(e) => setPrimaryStation(e.target.value)} onBlur={save} className={selectCls} style={{ width: "9rem" }}>
+            <option value="">— none —</option>
+            {STATION_OPTIONS.map((s) => <option key={s.value} value={s.value}>{s.label}</option>)}
+          </select>
+          <input type="number" min={0} placeholder="sec" value={primaryCookTime}
+            onChange={(e) => setPrimaryCookTime(e.target.value)} onBlur={save}
+            className={timeInputCls} />
+          <span className="text-xs text-zinc-600 w-10 shrink-0">{fmtSecs(parsePosInt(primaryCookTime) ?? 0)}</span>
+        </div>
+
+        {/* Arrow between stations */}
+        <span className="text-zinc-700 text-sm shrink-0">→</span>
+
+        {/* Secondary station + time */}
+        <div className="flex items-center gap-1.5 shrink-0">
+          <select value={secondaryStation} onChange={(e) => setSecondaryStation(e.target.value)} onBlur={save} className={selectCls} style={{ width: "9rem" }}>
+            <option value="">— none —</option>
+            {STATION_OPTIONS.map((s) => <option key={s.value} value={s.value}>{s.label}</option>)}
+          </select>
+          <input type="number" min={0} placeholder="sec" value={secondaryCookTime}
+            onChange={(e) => setSecondaryCookTime(e.target.value)} onBlur={save}
+            className={timeInputCls} />
+          <span className="text-xs text-zinc-600 w-10 shrink-0">{fmtSecs(parsePosInt(secondaryCookTime) ?? 0)}</span>
+        </div>
+
+        {/* Total */}
+        <div className="text-xs text-zinc-500 w-16 text-right shrink-0">
+          {totalSecs > 0 && (
+            <span className="text-white font-semibold">{fmtSecs(totalSecs)}</span>
+          )}
+          {totalSecs > 0 && <div className="text-zinc-600">total</div>}
+        </div>
+
+        {/* Portions per run */}
+        <input type="number" min={1} placeholder="—" value={portionCapacity}
+          onChange={(e) => setPortionCapacity(e.target.value)} onBlur={save}
+          className={`${timeInputCls} w-12`} title="Portions per run" />
+
+        {/* Status + delete */}
+        <div className="flex items-center gap-2 ml-auto shrink-0">
+          {saveState === "saving" && <Loader2 className="w-4 h-4 text-zinc-500 animate-spin" />}
+          {saveState === "saved"  && <Check className="w-4 h-4 text-emerald-400" />}
+          {saveState === "error"  && <AlertCircle className="w-4 h-4 text-red-400" />}
+
+          <button
+            onClick={handleDelete}
+            className={`flex items-center gap-1 px-2 py-1 rounded-lg text-xs font-semibold transition-colors ${
+              confirmDelete
+                ? "bg-red-600 text-white hover:bg-red-500"
+                : "text-zinc-600 hover:text-red-400 hover:bg-red-400/10"
+            }`}
+          >
+            <Trash2 className="w-3.5 h-3.5" />
+            {confirmDelete && "Confirm"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main tab
+// ---------------------------------------------------------------------------
+
+export function MenuEditorTab() {
+  const [items, setItems]           = useState<RawMenuItem[]>([]);
+  const [isLoading, setIsLoading]   = useState(true);
+  const [fetchError, setFetchError] = useState<string | null>(null);
+  const [search, setSearch]         = useState("");
+  const [category, setCategory]     = useState("All");
+  const [showAddModal, setShowAddModal] = useState(false);
+
+  useEffect(() => {
+    setIsLoading(true);
+    apiClient
+      .fetchMenu()
+      .then((data) => setItems(data as RawMenuItem[]))
+      .catch(() => setFetchError("Could not load menu. Is the server running?"))
+      .finally(() => setIsLoading(false));
+  }, []);
+
+  const categories = useMemo(() => {
+    const cats = new Set(items.map((i) => i.primaryCategory).filter((c): c is string => Boolean(c)));
+    return ["All", ...Array.from(cats).sort()];
+  }, [items]);
+
+  const filtered = useMemo(() => {
+    const q = search.toLowerCase();
+    return items.filter((i) => {
+      const matchSearch =
+        !q ||
+        i.name.en.toLowerCase().includes(q) ||
+        (i.name.zh ?? "").toLowerCase().includes(q) ||
+        i.id.toLowerCase().includes(q);
+      const matchCat = category === "All" || i.primaryCategory === category;
+      return matchSearch && matchCat;
+    });
+  }, [items, search, category]);
+
+  const handleSave = useCallback(async (id: string, updates: MenuItemUpdates) => {
+    await apiClient.updateMenuItem(id, updates);
+    setItems((prev) =>
+      prev.map((item) => {
+        if (item.id !== id) return item;
+        const patch: Partial<RawMenuItem> = {};
+        if (updates.primaryStation !== undefined)   patch.primaryStation   = updates.primaryStation   ?? undefined;
+        if (updates.primaryCookTime !== undefined)  patch.primaryCookTime  = updates.primaryCookTime  ?? undefined;
+        if (updates.secondaryStation !== undefined) patch.secondaryStation = updates.secondaryStation ?? undefined;
+        if (updates.secondaryCookTime !== undefined) patch.secondaryCookTime = updates.secondaryCookTime ?? undefined;
+        if (updates.portionCapacity !== undefined)  patch.portionCapacity  = updates.portionCapacity  ?? undefined;
+        return { ...item, ...patch };
+      }),
+    );
+  }, []);
+
+  const handleDelete = useCallback(async (id: string) => {
+    await apiClient.deleteMenuItem(id);
+    setItems((prev) => prev.filter((i) => i.id !== id));
+  }, []);
+
+  const handleAdd = useCallback((newItem: RawMenuItem) => {
+    setItems((prev) => [...prev, newItem]);
+  }, []);
+
+  if (isLoading) {
+    return (
+      <div className="flex-1 flex items-center justify-center text-zinc-500">
+        <Loader2 className="w-6 h-6 animate-spin mr-2" /> Loading menu…
+      </div>
+    );
+  }
+
+  if (fetchError) {
+    return (
+      <div className="flex-1 flex items-center justify-center text-red-400 gap-2">
+        <AlertCircle className="w-5 h-5" /> {fetchError}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col flex-1 min-h-0">
+      {/* Toolbar */}
+      <div className="flex items-center gap-3 px-4 py-3 border-b border-zinc-800 shrink-0">
+        <div className="relative flex-1 max-w-sm">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-zinc-500" />
+          <input
+            type="text"
+            placeholder="Search items…"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="w-full bg-zinc-900 border border-zinc-700 rounded-lg pl-9 pr-3 py-2 text-sm text-white placeholder-zinc-600 focus:outline-none focus:border-sky-500"
+          />
+        </div>
+        <select
+          value={category}
+          onChange={(e) => setCategory(e.target.value)}
+          className="bg-zinc-900 border border-zinc-700 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-sky-500"
+        >
+          {categories.map((c) => <option key={c} value={c}>{c}</option>)}
+        </select>
+        <span className="text-xs text-zinc-600 shrink-0">{filtered.length} item{filtered.length !== 1 ? "s" : ""}</span>
+        <button
+          onClick={() => setShowAddModal(true)}
+          className="ml-auto flex items-center gap-1.5 px-3 py-2 bg-sky-600 hover:bg-sky-500 text-white text-sm font-semibold rounded-lg transition-colors"
+        >
+          <Plus className="w-4 h-4" /> Add item
+        </button>
+      </div>
+
+      {/* Column headers */}
+      <div className="flex items-center gap-3 px-4 py-2 border-b border-zinc-800 shrink-0 text-[10px] uppercase tracking-widest text-zinc-600 font-semibold">
+        <div className="w-44 shrink-0">Item</div>
+        <div className="w-56 shrink-0">Primary station → time</div>
+        <div className="w-4 shrink-0" />
+        <div className="w-56 shrink-0">2nd station → time</div>
+        <div className="w-16 text-right shrink-0">Total</div>
+        <div className="w-12 text-right shrink-0" title="Portions per run">P/run</div>
+      </div>
+
+      {/* Hint for set meals */}
+      <div className="px-4 py-1.5 bg-purple-500/5 border-b border-purple-500/10 shrink-0">
+        <p className="text-[10px] text-purple-400/60">
+          Set meals <span className="text-zinc-600">—</span> assign the main bottleneck station and total expected time (e.g. ribs = 8 min). Child items inside the set can't be timed individually.
+        </p>
+      </div>
+
+      {/* Item list */}
+      <div className="flex-1 overflow-y-auto">
+        {filtered.length === 0 ? (
+          <div className="flex items-center justify-center h-32 text-zinc-600 text-sm">No items match</div>
+        ) : (
+          filtered.map((item) => (
+            <MenuItemRow key={item.id} item={item} onSave={handleSave} onDelete={handleDelete} />
+          ))
+        )}
+      </div>
+
+      {showAddModal && (
+        <AddItemModal
+          categories={categories}
+          onAdd={handleAdd}
+          onClose={() => setShowAddModal(false)}
+        />
+      )}
+    </div>
+  );
+}

--- a/client/src/components/layout/menu-editor-tab.tsx
+++ b/client/src/components/layout/menu-editor-tab.tsx
@@ -419,14 +419,13 @@ function MenuItemRow({ item, onSave, onDelete }: RowProps) {
 
 export function MenuEditorTab() {
   const [items, setItems]           = useState<RawMenuItem[]>([]);
-  const [isLoading, setIsLoading]   = useState(true);
+  const [isLoading, setIsLoading]   = useState(true); // true = loading until fetch resolves
   const [fetchError, setFetchError] = useState<string | null>(null);
   const [search, setSearch]         = useState("");
   const [category, setCategory]     = useState("All");
   const [showAddModal, setShowAddModal] = useState(false);
 
   useEffect(() => {
-    setIsLoading(true);
     apiClient
       .fetchMenu()
       .then((data) => setItems(data as RawMenuItem[]))

--- a/client/src/components/layout/pos-dashboard.tsx
+++ b/client/src/components/layout/pos-dashboard.tsx
@@ -113,7 +113,6 @@ export function PosDashboard() {
     setFocItem,
     updateItem,
     setCustomerInfo,
-    updatePayment,
     printOrder,
     setOrderType,
     clearOrder,
@@ -510,12 +509,8 @@ export function PosDashboard() {
               errorMessage={checkoutError}
               onConfirm={async (details) => {
                 setCheckoutError(null);
-                updatePayment({
-                  method: "cash",
-                  amount: details.amountPaid,
-                });
                 try {
-                  await printOrder();
+                  await printOrder(undefined, { method: "cash", amount: details.amountPaid });
                   setCheckoutError(null);
                   setIsCheckoutModalOpen(false);
                 } catch (error) {

--- a/client/src/components/modals/confirmation-modal.tsx
+++ b/client/src/components/modals/confirmation-modal.tsx
@@ -31,6 +31,8 @@ export function ConfirmationModal({
       setAmountPaidStr("");
     } else if (key === "." && amountPaidStr.includes(".")) {
       return;
+    } else if (!/^\d$/.test(key) && key !== ".") {
+      return; // reject comma and any other non-numeric character
     } else if (amountPaidStr.length < 8) {
       setAmountPaidStr((prev) => prev + key);
     }

--- a/client/src/config/index.ts
+++ b/client/src/config/index.ts
@@ -7,13 +7,20 @@
 interface Config {
   apiUrl: string;
   wsUrl: string;
-  adminPassword?: string;
+  adminApiToken?: string;
+  adminTokenMismatch: boolean;
 }
+
+const adminApiToken = import.meta.env.VITE_ADMIN_API_TOKEN;
+const legacyAdminPassword = import.meta.env.VITE_ADMIN_PASSWORD;
 
 export const config: Config = {
   apiUrl: import.meta.env.VITE_API_URL || "http://localhost:4000/api",
   wsUrl: import.meta.env.VITE_WS_URL || "ws://localhost:4000",
-  // Prefer explicit token naming, keep legacy VITE_ADMIN_PASSWORD for backwards compatibility.
-  adminPassword:
-    import.meta.env.VITE_ADMIN_API_TOKEN || import.meta.env.VITE_ADMIN_PASSWORD || undefined,
+  // Canonical key: VITE_ADMIN_API_TOKEN. Keep legacy fallback temporarily.
+  adminApiToken: adminApiToken || legacyAdminPassword || undefined,
+  adminTokenMismatch:
+    Boolean(adminApiToken) &&
+    Boolean(legacyAdminPassword) &&
+    adminApiToken !== legacyAdminPassword,
 };

--- a/client/src/context/OrderContext.tsx
+++ b/client/src/context/OrderContext.tsx
@@ -91,7 +91,7 @@ interface OrderContextType {
   setCustomerInfo: (info: CustomerInfo | undefined) => void;
   updatePayment: (payment: PaymentDetails) => void;
   setNotes: (notes?: string) => void;
-  printOrder: (orderToPrint?: FullOrder) => Promise<PrintResult>;
+  printOrder: (orderToPrint?: FullOrder, paymentOverride?: PaymentDetails) => Promise<PrintResult>;
   pendingPrintJobs: number;
   isFlushingPrintQueue: boolean;
   lastPrintAlert: string | null;
@@ -320,7 +320,7 @@ const generateInitialOrder = (id: number): OrderState => ({
 const OrderContext = createContext<OrderContextType | undefined>(undefined);
 
 function deriveTotals(order: OrderState) {
-  const subtotal = order.items.reduce((sum, item) => sum + item.price * item.quantity, 0);
+  const subtotal = order.items.reduce((sum, item) => sum + (item.finalPrice ?? item.price) * item.quantity, 0);
   const deliveryCharge =
     order.orderType === "delivery" ? calculateDeliveryCharge(order.customerInfo?.distance) : 0;
 
@@ -668,7 +668,7 @@ export function OrderProvider({ children }: { children: ReactNode }) {
     try {
       for (const job of queued) {
         try {
-          const result = await apiClient.submitOrder(job.order);
+          const result = await apiClient.submitOrder(job.order, job.clientOrderId);
           setPrintQueue((prev) =>
             prev.filter((entry) => entry.clientOrderId !== job.clientOrderId),
           );
@@ -727,7 +727,7 @@ export function OrderProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const printOrder = useCallback(
-    async (orderToPrint?: FullOrder): Promise<PrintResult> => {
+    async (orderToPrint?: FullOrder, paymentOverride?: PaymentDetails): Promise<PrintResult> => {
       const source = orderToPrint ? orderToPrint : order;
       const totals = deriveTotals(source as OrderState);
       const payload: FullOrder = {
@@ -751,7 +751,7 @@ export function OrderProvider({ children }: { children: ReactNode }) {
                   : undefined,
             }
           : undefined,
-        payment: { ...source.payment },
+        payment: paymentOverride ? { ...paymentOverride } : { ...source.payment },
         subtotal: totals.subtotal,
         deliveryCharge: totals.deliveryCharge,
         total: totals.total,
@@ -759,7 +759,7 @@ export function OrderProvider({ children }: { children: ReactNode }) {
       const clientOrderId = orderToPrint ? generateClientOrderId() : order.clientOrderId;
 
       try {
-        const result = await apiClient.submitOrder(payload);
+        const result = await apiClient.submitOrder(payload, clientOrderId);
         if (!orderToPrint) {
           clearOrder();
         }

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -138,10 +138,20 @@ export interface CallDetectedPayload {
   distance: number | null;
 }
 
-export type WebSocketMessage = {
-  type: "incoming_call";
-  payload: CallDetectedPayload;
-};
+export type OrderStatus =
+  | "new"
+  | "accepted"
+  | "cooking"
+  | "ready"
+  | "complete"
+  | "cancelled";
+
+export type WebSocketMessage =
+  | { type: "incoming_call"; payload: CallDetectedPayload }
+  | { type: "order_created"; payload: { orderId: number; order: FullOrder; archivedAt: string; status: OrderStatus } }
+  | { type: "order_status_changed"; payload: { orderId: number; previousStatus: OrderStatus; status: OrderStatus; updatedAt: string } }
+  | { type: "order_cancelled"; payload: { orderId: number } }
+  | { type: "order_eta_updated"; payload: { orderId: number; estimatedReadyAt: string } };
 
 export interface ApiError {
   error: {

--- a/kitchen/README.md
+++ b/kitchen/README.md
@@ -1,0 +1,129 @@
+# Kitchen Display Screen
+
+A real-time Kanban board for the kitchen. Shows active orders in three columns — **New**, **Cooking**, and **Ready** — and lets staff advance each order through the status pipeline by tapping one button.
+
+---
+
+## Running locally
+
+```bash
+# 1. Start the server first (required for API + WebSocket)
+cd ../server && npm run dev
+
+# 2. Start the kitchen screen
+cd kitchen
+npm install
+npm run dev        # http://localhost:5174
+```
+
+The Vite dev server proxies `/api` and `/ws` to `http://localhost:4000`, so no extra config is needed.
+
+---
+
+## Production build
+
+```bash
+npm run build      # outputs to kitchen/dist/
+npm run preview    # serve the built output locally
+```
+
+Point a static file server (nginx, Caddy, etc.) at `kitchen/dist/`. The kitchen screen only needs network access to the Express server.
+
+---
+
+## Architecture
+
+```
+kitchen/src/
+├── config.ts                  API_URL + WS_URL (empty = Vite proxy)
+├── types/kitchen.ts           All shared types: KitchenOrder, StationType, etc.
+├── hooks/
+│   ├── useKitchenSocket.ts    WebSocket connection with exponential backoff
+│   ├── useActiveOrders.ts     Fetch + live WS updates, race-condition safe buffering
+│   ├── useBusyMode.ts         Busy mode detection + priority card + miss-window ids
+│   ├── useCookTimer.ts        Estimated ready time, deadline, countdown formatting
+│   └── useStationLoad.ts      Per-station load derived from active orders + menu
+└── components/
+    ├── KitchenBoard.tsx        Root board: header, banners, station panel, columns
+    ├── KanbanColumn.tsx        One column (New / Cooking / Ready)
+    ├── OrderCard.tsx           Individual order card with all status/action logic
+    ├── CountdownTimer.tsx      Ticking deadline countdown (green → amber → red)
+    ├── WaitingTime.tsx         "Waiting Xs" badge on new orders
+    ├── DeliveryBadge.tsx       Delivery / Collection pill
+    ├── StationLoadPanel.tsx    Row of station load pips
+    ├── StationPip.tsx          Single station pip (idle / active / full / backlog)
+    └── BusyModeBanner.tsx      Amber banner shown in busy mode
+```
+
+---
+
+## Order status flow
+
+```
+new → accepted → cooking → ready → complete
+                                 ↘ cancelled
+```
+
+- **new**: order just came in; kitchen hasn't touched it yet
+- **accepted**: kitchen acknowledged — deadline clock started
+- **cooking**: active on the line
+- **ready**: food plated and waiting
+- **complete / cancelled**: terminal states, removed from active view
+
+Smart initialisation: if it's a collection order and the queue is empty, it skips straight to **cooking** automatically.
+
+---
+
+## Busy mode
+
+Busy mode activates when:
+- **Sustained load**: ≥ 4 active orders for 2 continuous minutes, OR
+- **Rush detection**: ≥ 3 new orders arrive within any 10-minute rolling window
+
+While busy:
+- Delivery deadlines extend from 37 min → 60 min
+- The highest-urgency order gets a golden "DO THIS NOW" priority badge
+- Orders that can't make their window get a pulsing red "Won't make window" warning
+- An amber busy-mode banner is shown across the top of the board
+
+---
+
+## Station load panel
+
+Tracks load across 9 station types:
+
+| Station | Description |
+|---------|-------------|
+| `dark_fryer` | For darker-battered items |
+| `light_fryer` | For lighter-battered items |
+| `oil_wok` | Dry-fried and high-heat dishes |
+| `wet_wok` | Sauced dishes (2 woks) |
+| `noodle_machine` | Auto noodle machines (3 total; 1 spicy-only) |
+| `microwave` | Defrosting only |
+| `sauce` | Sauce station (not a bottleneck — excluded from panel) |
+| `boiler` | Always-on for rice; shown as static "BOILER: ON" |
+
+Load states per station:
+- **Idle** (grey): nothing queued
+- **Active** (amber): 1–(slots) orders
+- **Full** (orange): at capacity
+- **Backlog** (red): more orders than slots
+
+---
+
+## Bilingual display
+
+All item names show English + Chinese (Noto Sans SC, amber tint) where translations exist in the menu. Modifiers also show their Chinese translation when available.
+
+---
+
+## WebSocket events consumed
+
+| Event | Action |
+|-------|--------|
+| `order_created` | Prepend new order card to New column |
+| `order_status_changed` | Move card to correct column |
+| `order_cancelled` | Remove card from board |
+| `order_eta_updated` | Update countdown timer on affected card |
+
+See the root [`README.md`](../README.md) for the full WS event payload schemas.

--- a/kitchen/index.html
+++ b/kitchen/index.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en" class="dark">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Kitchen Screen</title>
+    <!-- Prevent sleep on kitchen monitors -->
+    <meta name="mobile-web-app-capable" content="yes" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;600;700&family=JetBrains+Mono:wght@700&family=Noto+Sans+SC:wght@400;700&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      /* Prevent text selection on a touch-driven kitchen screen */
+      * { -webkit-user-select: none; user-select: none; }
+      html, body { height: 100%; overflow: hidden; background: #0a0a0a; }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/kitchen/package-lock.json
+++ b/kitchen/package-lock.json
@@ -1,0 +1,2064 @@
+{
+  "name": "kitchen",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "kitchen",
+      "version": "0.0.0",
+      "dependencies": {
+        "react": "^19.2.4",
+        "react-dom": "^19.2.4"
+      },
+      "devDependencies": {
+        "@types/node": "^24.12.0",
+        "@types/react": "^19.2.14",
+        "@types/react-dom": "^19.2.3",
+        "@vitejs/plugin-react": "^6.0.0",
+        "autoprefixer": "^10.4.19",
+        "postcss": "^8.4.47",
+        "tailwindcss": "^3.4.14",
+        "typescript": "~5.9.3",
+        "vite": "^8.0.0"
+      }
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.2.tgz",
+      "integrity": "sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.122.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.122.0.tgz",
+      "integrity": "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.12.tgz",
+      "integrity": "sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.12.tgz",
+      "integrity": "sha512-cFYr6zTG/3PXXF3pUO+umXxt1wkRK/0AYT8lDwuqvRC+LuKYWSAQAQZjCWDQpAH172ZV6ieYrNnFzVVcnSflAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.12.tgz",
+      "integrity": "sha512-ZCsYknnHzeXYps0lGBz8JrF37GpE9bFVefrlmDrAQhOEi4IOIlcoU1+FwHEtyXGx2VkYAvhu7dyBf75EJQffBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.12.tgz",
+      "integrity": "sha512-dMLeprcVsyJsKolRXyoTH3NL6qtsT0Y2xeuEA8WQJquWFXkEC4bcu1rLZZSnZRMtAqwtrF/Ib9Ddtpa/Gkge9Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.12.tgz",
+      "integrity": "sha512-YqWjAgGC/9M1lz3GR1r1rP79nMgo3mQiiA+Hfo+pvKFK1fAJ1bCi0ZQVh8noOqNacuY1qIcfyVfP6HoyBRZ85Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.12.tgz",
+      "integrity": "sha512-/I5AS4cIroLpslsmzXfwbe5OmWvSsrFuEw3mwvbQ1kDxJ822hFHIx+vsN/TAzNVyepI/j/GSzrtCIwQPeKCLIg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.12.tgz",
+      "integrity": "sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.12.tgz",
+      "integrity": "sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.12.tgz",
+      "integrity": "sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.12.tgz",
+      "integrity": "sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.12.tgz",
+      "integrity": "sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.12.tgz",
+      "integrity": "sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.12.tgz",
+      "integrity": "sha512-ykGiLr/6kkiHc0XnBfmFJuCjr5ZYKKofkx+chJWDjitX+KsJuAmrzWhwyOMSHzPhzOHOy7u9HlFoa5MoAOJ/Zg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.12.tgz",
+      "integrity": "sha512-5eOND4duWkwx1AzCxadcOrNeighiLwMInEADT0YM7xeEOOFcovWZCq8dadXgcRHSf3Ulh1kFo/qvzoFiCLOL1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.12.tgz",
+      "integrity": "sha512-PyqoipaswDLAZtot351MLhrlrh6lcZPo2LSYE+VDxbVk24LVKAGOuE4hb8xZQmrPAuEtTZW8E6D2zc5EUZX4Lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.7.tgz",
+      "integrity": "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.1.tgz",
+      "integrity": "sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rolldown/pluginutils": "1.0.0-rc.7"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
+        "babel-plugin-react-compiler": "^1.0.0",
+        "vite": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@rolldown/plugin-babel": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/autoprefixer": {
+      "version": "10.4.27",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.27.tgz",
+      "integrity": "sha512-NP9APE+tO+LuJGn7/9+cohklunJsXWiaWEfV3si4Gi/XHDwVNgkwr1J3RQYFIvPy76GmJ9/bW8vyoU1LcxwKHA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.28.1",
+        "caniuse-lite": "^1.0.30001774",
+        "fraction.js": "^5.3.4",
+        "picocolors": "^1.1.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.15",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.15.tgz",
+      "integrity": "sha512-1nfKCq9wuAZFTkA2ey/3OXXx7GzFjLdkTiFVNwlJ9WqdI706CZRIhEqjuwanjMIja+84jDLa9rcyZDPDiVkASQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/camelcase-css": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
+      "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001785",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001785.tgz",
+      "integrity": "sha512-blhOL/WNR+Km1RI/LCVAvA73xplXA7ZbjzI4YkMK9pa6T/P3F2GxjNpEkyw5repTw9IvkyrjyHpwjnhZ5FOvYQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/didyoumean": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
+      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/dlv": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.331",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.331.tgz",
+      "integrity": "sha512-IbxXrsTlD3hRodkLnbxAPP4OuJYdWCeM3IOdT+CpcMoIwIoDfCmRpEtSPfwBXxVkg9xmBeY7Lz2Eo2TDn/HC3Q==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fraction.js": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+      "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "1.21.7",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
+      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "bin/jiti.js"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.37",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
+      "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-import": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
+      "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "postcss-value-parser": "^4.0.0",
+        "read-cache": "^1.0.0",
+        "resolve": "^1.1.7"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.0"
+      }
+    },
+    "node_modules/postcss-js": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
+      "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "camelcase-css": "^2.0.1"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >= 16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.21"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "jiti": ">=1.21.0",
+        "postcss": ">=8.0.9",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/postcss-nested": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
+      "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.14"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
+      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/react": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
+      "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.4"
+      }
+    },
+    "node_modules/read-cache": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
+      "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pify": "^2.3.0"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.11",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
+      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.12.tgz",
+      "integrity": "sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.122.0",
+        "@rolldown/pluginutils": "1.0.0-rc.12"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.12",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.12",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.12",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.12",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.12",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.12",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.12",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.12",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.12",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.12",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.12",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.12",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.12",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.12",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.12"
+      }
+    },
+    "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.12.tgz",
+      "integrity": "sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sucrase": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "3.4.19",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
+      "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "arg": "^5.0.2",
+        "chokidar": "^3.6.0",
+        "didyoumean": "^1.2.2",
+        "dlv": "^1.1.3",
+        "fast-glob": "^3.3.2",
+        "glob-parent": "^6.0.2",
+        "is-glob": "^4.0.3",
+        "jiti": "^1.21.7",
+        "lilconfig": "^3.1.3",
+        "micromatch": "^4.0.8",
+        "normalize-path": "^3.0.0",
+        "object-hash": "^3.0.0",
+        "picocolors": "^1.1.1",
+        "postcss": "^8.4.47",
+        "postcss-import": "^15.1.0",
+        "postcss-js": "^4.0.1",
+        "postcss-load-config": "^4.0.2 || ^5.0 || ^6.0",
+        "postcss-nested": "^6.2.0",
+        "postcss-selector-parser": "^6.1.2",
+        "resolve": "^1.22.8",
+        "sucrase": "^3.35.0"
+      },
+      "bin": {
+        "tailwind": "lib/cli.js",
+        "tailwindcss": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.3.tgz",
+      "integrity": "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.8",
+        "rolldown": "1.0.0-rc.12",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.0",
+        "esbuild": "^0.27.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    }
+  }
+}

--- a/kitchen/package.json
+++ b/kitchen/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "kitchen",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite --port 5174",
+    "build": "tsc -b && vite build",
+    "lint": "eslint .",
+    "preview": "vite preview --port 5174"
+  },
+  "dependencies": {
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "@types/node": "^24.12.0",
+    "@vitejs/plugin-react": "^6.0.0",
+    "autoprefixer": "^10.4.19",
+    "postcss": "^8.4.47",
+    "tailwindcss": "^3.4.14",
+    "typescript": "~5.9.3",
+    "vite": "^8.0.0"
+  }
+}

--- a/kitchen/postcss.config.cjs
+++ b/kitchen/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/kitchen/src/App.tsx
+++ b/kitchen/src/App.tsx
@@ -1,0 +1,37 @@
+import { useEffect, useState } from "react";
+import type { MenuItem } from "./types/kitchen";
+import { KitchenBoard } from "./components/KitchenBoard";
+import { API_URL } from "./config";
+
+/**
+ * Fetches the menu from the server. Falls back to an empty array so the
+ * kitchen screen still works without cook time data (uses 8-min default).
+ */
+function useMenu(): MenuItem[] {
+  const [menu, setMenu] = useState<MenuItem[]>([]);
+
+  useEffect(() => {
+    fetch(`${API_URL}/api/menu`)
+      .then((r) => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        return r.json() as Promise<MenuItem[]>;
+      })
+      .then(setMenu)
+      .catch(() => {
+        // /api/menu not yet implemented — that's fine for Phase 1
+        // Cook times will use the 480s default until the endpoint exists
+      });
+  }, []);
+
+  return menu;
+}
+
+export default function App() {
+  const menu = useMenu();
+
+  return (
+    <div className="h-screen bg-[#0a0a0a] flex flex-col overflow-hidden font-sans">
+      <KitchenBoard menu={menu} />
+    </div>
+  );
+}

--- a/kitchen/src/components/BusyModeBanner.tsx
+++ b/kitchen/src/components/BusyModeBanner.tsx
@@ -1,0 +1,15 @@
+/**
+ * Full-width amber banner shown at the top of the screen during busy mode.
+ * Tells staff to stop making decisions and follow the system's priority card.
+ */
+export function BusyModeBanner() {
+  return (
+    <div className="flex items-center justify-center gap-3 px-6 py-2.5 bg-amber-500/10 border-b border-amber-500/30">
+      <span className="text-amber-400 text-lg">⚡</span>
+      <span className="font-bold tracking-widest uppercase text-amber-400 text-sm">
+        Busy Mode — Follow the highlighted order
+      </span>
+      <span className="text-amber-400 text-lg">⚡</span>
+    </div>
+  );
+}

--- a/kitchen/src/components/CountdownTimer.tsx
+++ b/kitchen/src/components/CountdownTimer.tsx
@@ -1,0 +1,48 @@
+import { useEffect, useState } from "react";
+import type { OrderStatus } from "../types/kitchen";
+import { formatCountdown, secondsUntil, timerColour } from "../hooks/useCookTimer";
+
+interface Props {
+  /** ISO deadline string — what the timer counts down to */
+  deadline: string;
+  status: OrderStatus;
+}
+
+const colourClass = {
+  green: "text-green-400",
+  amber: "text-amber-400",
+  red:   "text-red-500",
+} as const;
+
+/**
+ * Live countdown to the order's customer deadline.
+ * Updates every second. Turns amber at 5 min, red + pulses at 2 min / overdue.
+ */
+export function CountdownTimer({ deadline, status }: Props) {
+  const [secs, setSecs] = useState(() => secondsUntil(deadline));
+
+  useEffect(() => {
+    setSecs(secondsUntil(deadline));
+    const id = setInterval(() => setSecs(secondsUntil(deadline)), 1_000);
+    return () => clearInterval(id);
+  }, [deadline]);
+
+  if (status === "ready" || status === "complete") {
+    return <span className="text-zinc-500 font-mono font-bold text-lg">READY</span>;
+  }
+
+  const colour = timerColour(secs);
+  const isUrgent = colour === "red";
+
+  return (
+    <span
+      className={[
+        "font-mono font-bold text-xl tabular-nums leading-none",
+        colourClass[colour],
+        isUrgent ? "animate-pulse-red" : "",
+      ].join(" ")}
+    >
+      {formatCountdown(secs)}
+    </span>
+  );
+}

--- a/kitchen/src/components/DeliveryBadge.tsx
+++ b/kitchen/src/components/DeliveryBadge.tsx
@@ -1,0 +1,25 @@
+interface Props {
+  orderType: "collection" | "delivery";
+}
+
+/**
+ * Small pill badge indicating delivery or collection.
+ * Delivery is amber (requires driver); collection is zinc (just hand over counter).
+ */
+export function DeliveryBadge({ orderType }: Props) {
+  const isDelivery = orderType === "delivery";
+
+  return (
+    <span
+      className={[
+        "inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full",
+        "text-xs font-bold tracking-widest uppercase",
+        isDelivery
+          ? "bg-amber-500/15 text-amber-400 border border-amber-500/30"
+          : "bg-zinc-700/40 text-zinc-400 border border-zinc-600/30",
+      ].join(" ")}
+    >
+      {isDelivery ? "🛵 Delivery" : "🏃 Collection"}
+    </span>
+  );
+}

--- a/kitchen/src/components/KanbanColumn.tsx
+++ b/kitchen/src/components/KanbanColumn.tsx
@@ -1,0 +1,76 @@
+import type { KitchenOrder, OrderStatus } from "../types/kitchen";
+import { OrderCard } from "./OrderCard";
+
+interface Props {
+  title: string;
+  titleZh: string;
+  accentClass: string;
+  orders: KitchenOrder[];
+  priorityOrderId: number | null;
+  missWindowIds: number[];
+  batchMap: Map<number, number[]>;
+  onStatusChange: (orderId: number, status: OrderStatus) => void;
+}
+
+/**
+ * One of the three kanban columns (NEW / COOKING / READY).
+ * Scrolls internally so the header always stays visible.
+ */
+export function KanbanColumn({
+  title,
+  titleZh,
+  accentClass,
+  orders,
+  priorityOrderId,
+  missWindowIds,
+  batchMap,
+  onStatusChange,
+}: Props) {
+  return (
+    <div className="kanban-col flex flex-col flex-1 min-h-0">
+      {/* Column header */}
+      <div className="kanban-col-header">
+        <div className="flex items-baseline gap-2">
+          <div className={`w-2 h-2 rounded-full ${accentClass} shrink-0`} />
+          <div className="flex flex-col">
+            <span className="font-bold tracking-widest uppercase text-white text-sm">
+              {title}
+            </span>
+            <span className="font-chinese text-zinc-600 text-xs">{titleZh}</span>
+          </div>
+        </div>
+        <span
+          className={[
+            "text-sm font-mono font-bold px-2.5 py-0.5 rounded-full",
+            orders.length > 0
+              ? `${accentClass.replace("bg-", "bg-").replace("500", "500/15")} text-white border border-${accentClass.replace("bg-", "").replace("500", "500/40")}`
+              : "bg-zinc-800/60 text-zinc-600 border border-zinc-700/40",
+          ].join(" ")}
+        >
+          {orders.length}
+        </span>
+      </div>
+
+      {/* Scrollable card list */}
+      <div className="flex-1 overflow-y-auto p-3 space-y-3 min-h-0">
+        {orders.length === 0 ? (
+          <div className="flex flex-col items-center justify-center h-32 text-zinc-700">
+            <span className="text-3xl mb-2">○</span>
+            <span className="text-sm uppercase tracking-widest">Empty</span>
+          </div>
+        ) : (
+          orders.map((o) => (
+            <OrderCard
+              key={o.orderId}
+              kitchenOrder={o}
+              isPriority={o.orderId === priorityOrderId}
+              isMissWindow={missWindowIds.includes(o.orderId)}
+              batchWith={batchMap.get(o.orderId) ?? []}
+              onStatusChange={onStatusChange}
+            />
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/kitchen/src/components/KitchenBoard.tsx
+++ b/kitchen/src/components/KitchenBoard.tsx
@@ -1,0 +1,162 @@
+import { useEffect, useState } from "react";
+import type { MenuItem, OrderStatus } from "../types/kitchen";
+import { useActiveOrders } from "../hooks/useActiveOrders";
+import { useBusyMode } from "../hooks/useBusyMode";
+import { useStationLoad } from "../hooks/useStationLoad";
+import { useBatchDetection } from "../hooks/useBatchDetection";
+import { BusyModeBanner } from "./BusyModeBanner";
+import { KanbanColumn } from "./KanbanColumn";
+import { StationLoadPanel } from "./StationLoadPanel";
+
+// ---------------------------------------------------------------------------
+// Clock
+// ---------------------------------------------------------------------------
+
+function LiveClock() {
+  const [time, setTime] = useState(() => new Date());
+
+  useEffect(() => {
+    const id = setInterval(() => setTime(new Date()), 1_000);
+    return () => clearInterval(id);
+  }, []);
+
+  return (
+    <div className="text-right">
+      <div className="font-mono font-bold text-2xl text-white tabular-nums leading-none">
+        {time.toLocaleTimeString("en-GB", { hour: "2-digit", minute: "2-digit", second: "2-digit" })}
+      </div>
+      <div className="text-zinc-600 text-xs mt-0.5 tracking-wide">
+        {time.toLocaleDateString("en-GB", { weekday: "short", day: "numeric", month: "short" })}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Connection indicator
+// ---------------------------------------------------------------------------
+
+function ConnectionDot({ connected }: { connected: boolean }) {
+  return (
+    <div className="flex items-center gap-1.5">
+      <span
+        className={[
+          "w-2 h-2 rounded-full",
+          connected ? "bg-green-500 shadow-[0_0_6px_1px_rgba(34,197,94,0.6)]" : "bg-red-500 animate-pulse",
+        ].join(" ")}
+      />
+      <span className={`text-xs font-medium uppercase tracking-widest ${connected ? "text-green-500" : "text-red-400"}`}>
+        {connected ? "Live" : "Offline"}
+      </span>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main board
+// ---------------------------------------------------------------------------
+
+interface Props {
+  menu: MenuItem[];
+}
+
+export function KitchenBoard({ menu }: Props) {
+  const { orders, isLoading, connected, busyMode, setBusyMode, updateStatus } =
+    useActiveOrders(menu);
+
+  const { busyMode: derivedBusy, priorityOrderId, missWindowIds } =
+    useBusyMode(orders, busyMode);
+
+  // Sync derived busy mode back so useActiveOrders can recalculate delivery deadlines
+  useEffect(() => {
+    setBusyMode(derivedBusy);
+  }, [derivedBusy, setBusyMode]);
+
+  const stationLoad = useStationLoad(orders, menu);
+  const batchMap    = useBatchDetection(orders);
+
+  // Split orders into columns
+  const newOrders      = orders.filter((o) => o.status === "new");
+  const cookingOrders  = orders.filter((o) => o.status === "accepted" || o.status === "cooking");
+  const readyOrders    = orders.filter((o) => o.status === "ready");
+
+  const handleStatusChange = (orderId: number, status: OrderStatus) => {
+    void updateStatus(orderId, status);
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex-1 flex items-center justify-center">
+        <div className="flex flex-col items-center gap-4 text-zinc-600">
+          <div className="w-10 h-10 rounded-full border-2 border-zinc-700 border-t-amber-500 animate-spin" />
+          <span className="text-sm uppercase tracking-widest">Connecting to kitchen...</span>
+          <span className="font-chinese text-zinc-700">连接厨房系统中...</span>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* ── Header ──────────────────────────────────────────────────── */}
+      <header className="flex items-center justify-between px-5 py-3 bg-[#0c0c0c] border-b border-[#181818] shrink-0">
+        <div className="flex flex-col">
+          <span className="font-bold text-white text-lg tracking-wide leading-none">
+            Kitchen Screen
+          </span>
+          <span className="font-chinese text-zinc-600 text-sm mt-0.5">厨房显示屏</span>
+        </div>
+
+        <div className="flex items-center gap-5">
+          <ConnectionDot connected={connected} />
+          {derivedBusy && (
+            <span className="text-xs font-bold uppercase tracking-widest text-amber-400 bg-amber-400/10 border border-amber-400/20 px-3 py-1 rounded-full">
+              {orders.length} active
+            </span>
+          )}
+          <LiveClock />
+        </div>
+      </header>
+
+      {/* ── Busy mode banner ────────────────────────────────────────── */}
+      {derivedBusy && <BusyModeBanner />}
+
+      {/* ── Station load panel ──────────────────────────────────────── */}
+      <StationLoadPanel load={stationLoad} />
+
+      {/* ── Kanban columns ──────────────────────────────────────────── */}
+      <main className="flex-1 flex gap-3 p-3 min-h-0 overflow-hidden">
+        <KanbanColumn
+          title="New"
+          titleZh="新订单"
+          accentClass="bg-kitchen-new"
+          orders={newOrders}
+          priorityOrderId={derivedBusy ? priorityOrderId : null}
+          missWindowIds={missWindowIds}
+          batchMap={batchMap}
+          onStatusChange={handleStatusChange}
+        />
+        <KanbanColumn
+          title="Cooking"
+          titleZh="烹饪中"
+          accentClass="bg-kitchen-cooking"
+          orders={cookingOrders}
+          priorityOrderId={derivedBusy ? priorityOrderId : null}
+          missWindowIds={missWindowIds}
+          batchMap={batchMap}
+          onStatusChange={handleStatusChange}
+        />
+        <KanbanColumn
+          title="Ready"
+          titleZh="已就绪"
+          accentClass="bg-kitchen-ready"
+          orders={readyOrders}
+          priorityOrderId={null}
+          missWindowIds={[]}
+          batchMap={batchMap}
+          onStatusChange={handleStatusChange}
+        />
+      </main>
+    </div>
+  );
+}

--- a/kitchen/src/components/OrderCard.tsx
+++ b/kitchen/src/components/OrderCard.tsx
@@ -1,0 +1,355 @@
+import type { KitchenOrder, OrderItem, OrderModifier, OrderStatus } from "../types/kitchen";
+import { willMissWindow } from "../hooks/useCookTimer";
+import { CountdownTimer } from "./CountdownTimer";
+import { DeliveryBadge } from "./DeliveryBadge";
+import { WaitingTime } from "./WaitingTime";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function renderModifier(mod: string | OrderModifier): { en: string; zh?: string } {
+  if (typeof mod === "string") return { en: mod };
+  if (mod.ingredient) {
+    return { en: mod.ingredient.name ?? "", zh: mod.ingredient.zh };
+  }
+  return { en: mod.name ?? "", zh: mod.zh };
+}
+
+const NEXT_STATUS: Partial<Record<OrderStatus, OrderStatus>> = {
+  new:      "accepted",
+  accepted: "cooking",
+  cooking:  "ready",
+  ready:    "complete",
+};
+
+const BUTTON_LABEL: Record<string, string> = {
+  new:      "ACCEPT ORDER",
+  accepted: "START COOKING",
+  cooking:  "MARK READY",
+  "ready-collection": "COMPLETE",
+  "ready-delivery":   "DISPATCHED",
+};
+
+const STATUS_BAR: Partial<Record<OrderStatus, string>> = {
+  new:      "bg-kitchen-new",
+  accepted: "bg-kitchen-accepted",
+  cooking:  "bg-kitchen-cooking",
+  ready:    "bg-kitchen-ready",
+};
+
+const BUTTON_CLASS: Partial<Record<OrderStatus, string>> = {
+  new:      "action-btn action-btn-new",
+  accepted: "action-btn action-btn-accepted",
+  cooking:  "action-btn action-btn-cooking",
+  ready:    "action-btn action-btn-ready",
+};
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+function ItemRow({ item }: { item: OrderItem }) {
+  const isChild = !!item.parentId;
+  const modifiers = item.modifiers?.filter(
+    (m): m is string | OrderModifier => m !== null && m !== undefined,
+  ) ?? [];
+
+  return (
+    <div className={`${isChild ? "pl-4 opacity-80" : ""}`}>
+      {/* Name row */}
+      <div className="flex items-baseline gap-2">
+        {!item.hideQuantity && (
+          <span className="text-zinc-400 font-mono font-bold text-base shrink-0 w-6 text-right">
+            {item.quantity}×
+          </span>
+        )}
+        <div className="flex flex-col min-w-0">
+          <span className={`font-semibold text-white leading-snug ${isChild ? "text-base" : "text-lg"}`}>
+            {item.name}
+            {item.isFoc && (
+              <span className="ml-2 text-xs font-bold text-green-400 bg-green-400/10 px-1.5 py-0.5 rounded">
+                FOC
+              </span>
+            )}
+            {item.isSwapped && (
+              <span className="ml-2 text-xs font-bold text-blue-400 bg-blue-400/10 px-1.5 py-0.5 rounded">
+                SWAP
+              </span>
+            )}
+          </span>
+          {item.zhName && (
+            <span className="font-chinese text-amber-400/70 text-sm leading-snug">
+              {item.zhName}
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Modifiers */}
+      {modifiers.length > 0 && (
+        <div className="mt-1 pl-8 space-y-0.5">
+          {modifiers.map((mod, i) => {
+            const { en, zh } = renderModifier(mod);
+            if (!en && !zh) return null;
+            return (
+              <div key={i} className="flex items-baseline gap-2">
+                <span className="text-amber-400 text-sm">⚠</span>
+                <span className="text-amber-400 font-bold text-sm uppercase tracking-wide">
+                  {en}
+                  {zh && (
+                    <span className="font-chinese font-normal normal-case ml-2 text-amber-400/70">
+                      {zh}
+                    </span>
+                  )}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// Early/late badge shown once order is 'ready'
+function ScheduleBadge({ estimatedReadyAt, actualReadyAt }: { estimatedReadyAt: string; actualReadyAt: string }) {
+  const diffMs = new Date(estimatedReadyAt).getTime() - new Date(actualReadyAt).getTime();
+  const diffMin = Math.round(Math.abs(diffMs) / 60_000);
+  const early = diffMs > 0;
+
+  if (diffMin === 0) return null;
+
+  return (
+    <span
+      className={[
+        "text-xs font-bold px-2 py-0.5 rounded-full",
+        early
+          ? "bg-green-500/15 text-green-400 border border-green-500/30"
+          : "bg-red-500/15 text-red-400 border border-red-500/30",
+      ].join(" ")}
+    >
+      {early ? `✓ ${diffMin} min early` : `✗ ${diffMin} min late`}
+    </span>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// ETA helpers
+// ---------------------------------------------------------------------------
+
+/** Minutes of drive time per mile — conservative local estimate */
+const DRIVE_MINS_PER_MILE = 3.5;
+
+function fmtTime(date: Date): string {
+  return date.toLocaleTimeString("en-GB", { hour: "2-digit", minute: "2-digit" });
+}
+
+function deliveryEta(estimatedReadyAt: string, distanceMiles: number | null | undefined): Date | null {
+  if (distanceMiles == null || distanceMiles <= 0) return null;
+  const driveMs = distanceMiles * DRIVE_MINS_PER_MILE * 60_000;
+  return new Date(new Date(estimatedReadyAt).getTime() + driveMs);
+}
+
+// ---------------------------------------------------------------------------
+// Interface
+// ---------------------------------------------------------------------------
+
+interface Props {
+  kitchenOrder: KitchenOrder;
+  isPriority: boolean;
+  isMissWindow: boolean;
+  batchWith: number[];
+  onStatusChange: (orderId: number, status: OrderStatus) => void;
+}
+
+export function OrderCard({ kitchenOrder, isPriority, isMissWindow, batchWith, onStatusChange }: Props) {
+  const { orderId, order, status, archivedAt, estimatedReadyAt, actualReadyAt, deadline } = kitchenOrder;
+  const isDelivery = order.orderType === "delivery";
+
+  const nextStatus = NEXT_STATUS[status];
+  const labelKey =
+    status === "ready"
+      ? isDelivery ? "ready-delivery" : "ready-collection"
+      : status;
+  const buttonLabel = BUTTON_LABEL[labelKey] ?? "";
+
+  const missWindow = willMissWindow(estimatedReadyAt, deadline, status);
+  const etaDelivery = isDelivery
+    ? deliveryEta(estimatedReadyAt, order.customerInfo?.distance)
+    : null;
+  const readyTime = new Date(estimatedReadyAt);
+
+  // Card styling
+  const cardClass = [
+    "order-card",
+    isPriority ? "order-card-priority" : "",
+    isMissWindow && !isPriority ? "order-card-urgent" : "",
+  ].filter(Boolean).join(" ");
+
+  // Top-left status bar colour — urgent overrides status colour
+  const barClass = missWindow
+    ? "bg-red-500 animate-pulse-red"
+    : (STATUS_BAR[status] ?? "bg-zinc-700");
+
+  // Top items: exclude children (set meal components shown under their parent)
+  const topItems = order.items.filter((i) => !i.parentId);
+
+  return (
+    <article className={cardClass}>
+      {/* Status bar — left edge colour indicator */}
+      <div className={`status-bar ${barClass}`} />
+
+      {/* Card content — left-padded to clear status bar */}
+      <div className="pl-3 pr-4 pt-3 pb-4 flex flex-col gap-3">
+
+        {/* ── Header ──────────────────────────────────────────────── */}
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex flex-col gap-1 min-w-0">
+            {/* Order number */}
+            <div className="flex items-center gap-2 flex-wrap">
+              <span className="font-mono font-bold text-3xl text-white tracking-tight leading-none">
+                #{String(orderId).padStart(3, "0")}
+              </span>
+              <DeliveryBadge orderType={order.orderType} />
+              {isPriority && (
+                <span className="text-xs font-bold tracking-widest uppercase text-amber-400 bg-amber-400/10 border border-amber-400/30 px-2 py-0.5 rounded-full animate-pulse-red">
+                  DO THIS NOW
+                </span>
+              )}
+              {batchWith.length > 0 && (
+                <span className="text-xs font-bold tracking-wide uppercase text-emerald-400 bg-emerald-400/10 border border-emerald-400/30 px-2 py-0.5 rounded-full">
+                  BATCH w/ {batchWith.map((id) => `#${String(id).padStart(3, "0")}`).join(" ")}
+                </span>
+              )}
+            </div>
+
+            {/* ETA row — shown while order is not yet complete */}
+            {status !== "complete" && status !== "cancelled" && (
+              <div className="flex items-center gap-3 text-xs text-zinc-500 flex-wrap">
+                <span>
+                  Ready <span className="text-zinc-300 font-semibold">{fmtTime(readyTime)}</span>
+                </span>
+                {etaDelivery && (
+                  <>
+                    <span className="text-zinc-700">·</span>
+                    <span>
+                      Delivery ETA{" "}
+                      <span className="text-amber-400 font-semibold">{fmtTime(etaDelivery)}</span>
+                    </span>
+                  </>
+                )}
+              </div>
+            )}
+
+            {/* Won't make window warning */}
+            {missWindow && (
+              <div className="flex items-center gap-1.5 text-sm font-bold text-red-400 animate-pulse-red">
+                <span>⚠</span>
+                <span className="uppercase tracking-wide">Won't make window</span>
+              </div>
+            )}
+
+            {/* Waiting time — new orders only */}
+            {status === "new" && <WaitingTime archivedAt={archivedAt} />}
+
+            {/* Early/late badge — ready orders only */}
+            {status === "ready" && actualReadyAt && (
+              <ScheduleBadge estimatedReadyAt={estimatedReadyAt} actualReadyAt={actualReadyAt} />
+            )}
+          </div>
+
+          {/* Countdown timer */}
+          <div className="shrink-0 text-right">
+            <CountdownTimer deadline={deadline} status={status} />
+            <div className="text-[10px] text-zinc-600 uppercase tracking-widest mt-0.5">deadline</div>
+          </div>
+        </div>
+
+        {/* ── Divider ─────────────────────────────────────────────── */}
+        <div className="border-t border-[#1e1e1e]" />
+
+        {/* ── Items ───────────────────────────────────────────────── */}
+        <div className="flex flex-col gap-2.5">
+          {topItems.map((item) => {
+            const children = order.items.filter((c) => c.parentId === item.uniqueId);
+            return (
+              <div key={item.uniqueId}>
+                <ItemRow item={item} />
+                {children.map((child) => (
+                  <div key={child.uniqueId} className="mt-1.5">
+                    <ItemRow item={child} />
+                  </div>
+                ))}
+              </div>
+            );
+          })}
+        </div>
+
+        {/* ── Notes ───────────────────────────────────────────────── */}
+        {order.notes && (
+          <div className="flex items-start gap-2 bg-amber-500/8 border border-amber-500/20 rounded-lg px-3 py-2">
+            <span className="text-amber-400 shrink-0">📝</span>
+            <span className="text-amber-300 text-sm font-medium">{order.notes}</span>
+          </div>
+        )}
+
+        {/* ── Customer info — delivery only ────────────────────────── */}
+        {isDelivery && order.customerInfo && (
+          <>
+            <div className="border-t border-[#1e1e1e]" />
+            <div className="flex items-center gap-2 text-zinc-400 text-base">
+              <span className="text-zinc-600">📍</span>
+              <span className="font-medium">
+                {order.customerInfo.name && (
+                  <span className="text-zinc-300 mr-1">{order.customerInfo.name} ·</span>
+                )}
+                {order.customerInfo.postcode}
+              </span>
+            </div>
+            {order.customerInfo.deliveryInstructions && (
+              <div className="text-zinc-500 text-sm pl-6 italic">
+                {order.customerInfo.deliveryInstructions}
+              </div>
+            )}
+          </>
+        )}
+
+        {/* ── Delivery time (if specified) ─────────────────────────── */}
+        {order.customerInfo?.deliveryTime && (
+          <div className="flex items-center gap-2 text-sm text-zinc-500">
+            <span>🕐</span>
+            <span>For {order.customerInfo.deliveryTime}</span>
+          </div>
+        )}
+
+        {/* ── Action button ────────────────────────────────────────── */}
+        {nextStatus && (
+          <>
+            <div className="border-t border-[#1e1e1e]" />
+            <button
+              onClick={() => onStatusChange(orderId, nextStatus)}
+              className={[
+                BUTTON_CLASS[status] ?? "action-btn",
+                isPriority ? "action-btn-priority" : "",
+              ].filter(Boolean).join(" ")}
+            >
+              {buttonLabel}
+            </button>
+          </>
+        )}
+
+        {/* Completed state — no button */}
+        {status === "complete" && (
+          <div className="text-center text-zinc-600 text-sm uppercase tracking-widest py-2">
+            Complete
+          </div>
+        )}
+      </div>
+    </article>
+  );
+}

--- a/kitchen/src/components/StationLoadPanel.tsx
+++ b/kitchen/src/components/StationLoadPanel.tsx
@@ -1,0 +1,33 @@
+import type { StationLoadMap } from "../types/kitchen";
+import { TRACKED_STATIONS } from "../types/kitchen";
+import { StationPip } from "./StationPip";
+
+interface Props {
+  load: StationLoadMap;
+}
+
+/**
+ * Horizontal strip showing live capacity for all tracked kitchen stations.
+ * Boiler is shown as a static always-on indicator (not per-order tracked).
+ * Sauce station is excluded (never a bottleneck).
+ */
+export function StationLoadPanel({ load }: Props) {
+  return (
+    <div className="flex items-center gap-2 px-4 py-2 bg-[#0a0a0a] border-b border-[#181818] overflow-x-auto">
+      <span className="text-[10px] font-bold tracking-widest uppercase text-zinc-700 shrink-0 mr-1">
+        Stations
+      </span>
+
+      {TRACKED_STATIONS.map((station) => (
+        <StationPip key={station} station={station} load={load[station]} />
+      ))}
+
+      {/* Boiler — always on, static indicator */}
+      <div className="flex flex-col items-center gap-1.5 px-3 py-2 rounded-lg bg-[#0f0f0f] border border-[#1a1a1a] min-w-[72px]">
+        <span className="text-[10px] font-bold tracking-widest uppercase text-zinc-600">BOILER</span>
+        <span className="w-2.5 h-2.5 rounded-full bg-blue-500 shadow-[0_0_6px_1px_rgba(59,130,246,0.5)]" />
+        <span className="text-xs font-bold text-blue-400">ON</span>
+      </div>
+    </div>
+  );
+}

--- a/kitchen/src/components/StationPip.tsx
+++ b/kitchen/src/components/StationPip.tsx
@@ -1,0 +1,66 @@
+import type { StationLoad, StationType } from "../types/kitchen";
+import { STATION_LABELS } from "../types/kitchen";
+
+interface Props {
+  station: StationType;
+  load: StationLoad | undefined;
+}
+
+/**
+ * Single station capacity indicator.
+ *
+ * States:
+ *   idle      (0 / capacity)           → zinc, dim
+ *   active    (> 0, < capacity)        → green
+ *   full      (= capacity, no queue)   → amber
+ *   backlog   (= capacity + queued)    → red
+ */
+export function StationPip({ station, load }: Props) {
+  const { used = 0, capacity = 1, queued = 0 } = load ?? {};
+
+  const state =
+    used === 0    ? "idle" :
+    queued > 0    ? "backlog" :
+    used >= capacity ? "full" :
+                    "active";
+
+  const colours = {
+    idle:    { dot: "bg-zinc-700",   text: "text-zinc-600",  ring: "" },
+    active:  { dot: "bg-green-500",  text: "text-green-400", ring: "shadow-[0_0_8px_1px_rgba(34,197,94,0.4)]" },
+    full:    { dot: "bg-amber-500",  text: "text-amber-400", ring: "shadow-[0_0_8px_1px_rgba(245,158,11,0.4)]" },
+    backlog: { dot: "bg-red-500",    text: "text-red-400",   ring: "shadow-[0_0_8px_1px_rgba(239,68,68,0.5)]" },
+  } as const;
+
+  const c = colours[state];
+
+  // Build slot indicators (filled dots)
+  const dots = Array.from({ length: capacity }, (_, i) => i < used);
+
+  return (
+    <div className="flex flex-col items-center gap-1.5 px-3 py-2 rounded-lg bg-[#0f0f0f] border border-[#1a1a1a] min-w-[72px]">
+      {/* Label */}
+      <span className="text-[10px] font-bold tracking-widest uppercase text-zinc-600 whitespace-nowrap">
+        {STATION_LABELS[station]}
+      </span>
+
+      {/* Slot dots */}
+      <div className="flex items-center gap-1">
+        {dots.map((filled, i) => (
+          <span
+            key={i}
+            className={[
+              "w-2.5 h-2.5 rounded-full transition-all duration-300",
+              filled ? `${c.dot} ${c.ring}` : "bg-zinc-800",
+            ].join(" ")}
+          />
+        ))}
+      </div>
+
+      {/* Count label */}
+      <span className={`text-xs font-bold tabular-nums leading-none ${c.text}`}>
+        {used}/{capacity}
+        {queued > 0 && <span className="text-red-400 ml-1">+{queued}</span>}
+      </span>
+    </div>
+  );
+}

--- a/kitchen/src/components/WaitingTime.tsx
+++ b/kitchen/src/components/WaitingTime.tsx
@@ -1,0 +1,48 @@
+import { useEffect, useState } from "react";
+
+interface Props {
+  archivedAt: string;
+}
+
+function waitingSeconds(archivedAt: string) {
+  return Math.max(0, Math.round((Date.now() - new Date(archivedAt).getTime()) / 1_000));
+}
+
+function formatWaiting(secs: number): string {
+  if (secs < 60) return `${secs}s`;
+  const m = Math.floor(secs / 60);
+  const s = secs % 60;
+  return s > 0 ? `${m}m ${s}s` : `${m}m`;
+}
+
+/**
+ * Counts up from the moment an order was placed.
+ * Shown on 'new' cards only — tells staff how long an order has been waiting unaccepted.
+ *
+ * Colour:
+ *   < 3 min → zinc (neutral)
+ *   3–6 min → amber (hold is getting long)
+ *   > 6 min → red   (batch window has likely closed)
+ */
+export function WaitingTime({ archivedAt }: Props) {
+  const [secs, setSecs] = useState(() => waitingSeconds(archivedAt));
+
+  useEffect(() => {
+    setSecs(waitingSeconds(archivedAt));
+    const id = setInterval(() => setSecs(waitingSeconds(archivedAt)), 1_000);
+    return () => clearInterval(id);
+  }, [archivedAt]);
+
+  const mins = secs / 60;
+  const colourClass =
+    mins >= 6 ? "text-red-400" :
+    mins >= 3 ? "text-amber-400" :
+                "text-zinc-500";
+
+  return (
+    <div className={`flex items-center gap-1.5 text-sm font-medium ${colourClass}`}>
+      <span>⏳</span>
+      <span>Waiting {formatWaiting(secs)}</span>
+    </div>
+  );
+}

--- a/kitchen/src/config.ts
+++ b/kitchen/src/config.ts
@@ -1,0 +1,11 @@
+export const API_URL = import.meta.env.VITE_API_URL ?? "";
+// Empty string → uses Vite proxy (same origin), which forwards to localhost:4000.
+// Set VITE_API_URL in .env if deploying kitchen screen separately.
+
+export const WS_URL = (() => {
+  const override = import.meta.env.VITE_WS_URL as string | undefined;
+  if (override) return override;
+  // Derive from current page origin — /ws is proxied by Vite to localhost:4000
+  const proto = window.location.protocol === "https:" ? "wss:" : "ws:";
+  return `${proto}//${window.location.host}/ws`;
+})();

--- a/kitchen/src/hooks/useActiveOrders.ts
+++ b/kitchen/src/hooks/useActiveOrders.ts
@@ -1,0 +1,213 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { API_URL } from "../config";
+import type {
+  KitchenOrder,
+  KitchenSocketEvent,
+  MenuItem,
+  OrderStatus,
+} from "../types/kitchen";
+import { calcDeadline, calcEstimatedReady } from "./useCookTimer";
+import { useKitchenSocket } from "./useKitchenSocket";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const INACTIVE: OrderStatus[] = ["complete", "cancelled"];
+
+function mapApiRow(
+  row: {
+    orderId: number;
+    order: KitchenOrder["order"];
+    status: OrderStatus;
+    archivedAt: string;
+    actualReadyAt?: string | null;
+  },
+  menu: MenuItem[],
+  busyMode: boolean,
+): KitchenOrder {
+  return {
+    orderId: row.orderId,
+    order: row.order,
+    status: row.status,
+    archivedAt: row.archivedAt,
+    estimatedReadyAt: calcEstimatedReady(row.order, menu, row.archivedAt).toISOString(),
+    actualReadyAt: row.actualReadyAt ?? undefined,
+    deadline: calcDeadline(row.order.orderType, row.archivedAt, busyMode).toISOString(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetches active orders on mount, then keeps state in sync with WebSocket events.
+ *
+ * Race-condition safe: WS events that arrive before the initial fetch resolves
+ * are buffered and replayed after the fetch completes.
+ */
+export function useActiveOrders(menu: MenuItem[]) {
+  const [orders, setOrders] = useState<KitchenOrder[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [busyMode, setBusyMode] = useState(false);
+
+  // Keep a stable ref to the current menu so callbacks don't go stale
+  const menuRef = useRef(menu);
+  useEffect(() => { menuRef.current = menu; });
+
+  const busyModeRef = useRef(busyMode);
+  useEffect(() => { busyModeRef.current = busyMode; });
+
+  // Buffer WS events received before the fetch completes
+  const fetchedRef = useRef(false);
+  const pendingRef = useRef<KitchenSocketEvent[]>([]);
+
+  const applyEvent = useCallback(
+    (event: KitchenSocketEvent, prev: KitchenOrder[]): KitchenOrder[] => {
+      switch (event.type) {
+        case "order_created": {
+          if (prev.some((o) => o.orderId === event.payload.orderId)) return prev;
+          const mapped = mapApiRow(
+            {
+              orderId: event.payload.orderId,
+              order: event.payload.order,
+              status: event.payload.status,
+              archivedAt: event.payload.archivedAt,
+            },
+            menuRef.current,
+            busyModeRef.current,
+          );
+          return [...prev, mapped];
+        }
+
+        case "order_status_changed": {
+          return prev
+            .map((o) =>
+              o.orderId === event.payload.orderId
+                ? {
+                    ...o,
+                    status: event.payload.status,
+                    actualReadyAt:
+                      event.payload.status === "ready"
+                        ? event.payload.updatedAt
+                        : o.actualReadyAt,
+                  }
+                : o,
+            )
+            .filter((o) => !INACTIVE.includes(o.status));
+        }
+
+        case "order_cancelled":
+          return prev.filter((o) => o.orderId !== event.payload.orderId);
+
+        case "order_eta_updated":
+          return prev.map((o) =>
+            o.orderId === event.payload.orderId
+              ? { ...o, estimatedReadyAt: event.payload.estimatedReadyAt }
+              : o,
+          );
+
+        default:
+          return prev;
+      }
+    },
+    [],
+  );
+
+  const handleSocketEvent = useCallback(
+    (event: KitchenSocketEvent) => {
+      if (!fetchedRef.current) {
+        pendingRef.current.push(event);
+        return;
+      }
+      setOrders((prev) => applyEvent(event, prev));
+    },
+    [applyEvent],
+  );
+
+  const { connected } = useKitchenSocket(handleSocketEvent);
+
+  // Initial fetch
+  useEffect(() => {
+    let cancelled = false;
+
+    fetch(`${API_URL}/api/orders/active`)
+      .then((r) => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        return r.json() as Promise<{ orders: Parameters<typeof mapApiRow>[0][] }>;
+      })
+      .then(({ orders: rows }) => {
+        if (cancelled) return;
+
+        // Derive initial busyMode from queue depth
+        const isBusy = rows.length >= 4;
+        setBusyMode(isBusy);
+        busyModeRef.current = isBusy;
+
+        let merged: KitchenOrder[] = rows.map((row) =>
+          mapApiRow(row, menuRef.current, isBusy),
+        );
+
+        // Replay buffered WS events
+        for (const evt of pendingRef.current) {
+          merged = applyEvent(evt, merged);
+        }
+        pendingRef.current = [];
+        fetchedRef.current = true;
+
+        setOrders(merged);
+        setIsLoading(false);
+      })
+      .catch(() => {
+        if (!cancelled) {
+          fetchedRef.current = true;
+          setIsLoading(false);
+        }
+      });
+
+    return () => { cancelled = true; };
+  }, [applyEvent]);
+
+  // Recalculate deadlines whenever busyMode changes (delivery windows shift)
+  useEffect(() => {
+    setOrders((prev) =>
+      prev.map((o) => ({
+        ...o,
+        deadline: calcDeadline(o.order.orderType, o.archivedAt, busyMode).toISOString(),
+      })),
+    );
+  }, [busyMode]);
+
+  const updateStatus = useCallback(
+    async (orderId: number, status: OrderStatus) => {
+      // Optimistic update
+      setOrders((prev) =>
+        prev
+          .map((o) =>
+            o.orderId === orderId
+              ? {
+                  ...o,
+                  status,
+                  actualReadyAt: status === "ready" ? new Date().toISOString() : o.actualReadyAt,
+                }
+              : o,
+          )
+          .filter((o) => !INACTIVE.includes(o.status)),
+      );
+
+      try {
+        await fetch(`${API_URL}/api/orders/${orderId}/status`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ status }),
+        });
+      } catch {
+        // WS event from server will reconcile if the request eventually succeeds
+      }
+    },
+    [],
+  );
+
+  return { orders, isLoading, connected, busyMode, setBusyMode, updateStatus };
+}

--- a/kitchen/src/hooks/useBatchDetection.ts
+++ b/kitchen/src/hooks/useBatchDetection.ts
@@ -1,0 +1,81 @@
+import { useMemo } from "react";
+import type { KitchenOrder } from "../types/kitchen";
+
+/**
+ * Detects delivery orders that are good candidates to batch together —
+ * i.e. send with the same driver in one run.
+ *
+ * Criteria (all must be true for a pair):
+ *  - Both are delivery orders
+ *  - Both are 'new' (not yet accepted — once accepted the cook is started)
+ *  - Both have coordinates
+ *  - Placed within BATCH_TIME_WINDOW_MS of each other
+ *  - Delivery addresses are within BATCH_DISTANCE_MILES of each other
+ *
+ * Returns a Map<orderId, orderId[]> — each entry lists orders that can be
+ * batched with that order.
+ */
+
+const BATCH_DISTANCE_MILES  = 1.2;   // addresses this close = same direction
+const BATCH_TIME_WINDOW_MS  = 20 * 60_000; // placed within 20 min of each other
+
+function distanceMiles(
+  lat1: number, lon1: number,
+  lat2: number, lon2: number,
+): number {
+  const R    = 3958.8;
+  const dLat = ((lat2 - lat1) * Math.PI) / 180;
+  const dLon = ((lon2 - lon1) * Math.PI) / 180;
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos((lat1 * Math.PI) / 180) *
+    Math.cos((lat2 * Math.PI) / 180) *
+    Math.sin(dLon / 2) ** 2;
+  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
+export function useBatchDetection(
+  orders: KitchenOrder[],
+): Map<number, number[]> {
+  return useMemo(() => {
+    // Only 'new' delivery orders with coordinates are candidates
+    const candidates = orders.filter((o) => {
+      if (o.order.orderType !== "delivery") return false;
+      if (o.status !== "new") return false;
+      const ci = o.order.customerInfo;
+      return ci?.latitude != null && ci?.longitude != null;
+    });
+
+    const batchMap = new Map<number, number[]>();
+
+    for (let i = 0; i < candidates.length; i++) {
+      for (let j = i + 1; j < candidates.length; j++) {
+        const a = candidates[i];
+        const b = candidates[j];
+
+        // Time window check
+        const timeDiff = Math.abs(
+          new Date(a.archivedAt).getTime() - new Date(b.archivedAt).getTime(),
+        );
+        if (timeDiff > BATCH_TIME_WINDOW_MS) continue;
+
+        // Distance check
+        const ciA = a.order.customerInfo!;
+        const ciB = b.order.customerInfo!;
+        const dist = distanceMiles(
+          ciA.latitude!,  ciA.longitude!,
+          ciB.latitude!,  ciB.longitude!,
+        );
+        if (dist > BATCH_DISTANCE_MILES) continue;
+
+        // They're batchable — add each to the other's list
+        if (!batchMap.has(a.orderId)) batchMap.set(a.orderId, []);
+        if (!batchMap.has(b.orderId)) batchMap.set(b.orderId, []);
+        batchMap.get(a.orderId)!.push(b.orderId);
+        batchMap.get(b.orderId)!.push(a.orderId);
+      }
+    }
+
+    return batchMap;
+  }, [orders]);
+}

--- a/kitchen/src/hooks/useBusyMode.ts
+++ b/kitchen/src/hooks/useBusyMode.ts
@@ -1,0 +1,111 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { KitchenOrder } from "../types/kitchen";
+import { willMissWindow } from "./useCookTimer";
+
+const BUSY_THRESHOLD = 4;
+const SUSTAINED_MS = 2 * 60 * 1_000;   // must exceed threshold for 2 min to activate
+const WINDOW_MS     = 10 * 60 * 1_000;  // rolling window for arrival rate
+const ARRIVAL_TRIGGER = 3;              // orders in WINDOW_MS triggers busy mode
+
+/**
+ * Derives busy mode state with smoothing to prevent false positives.
+ *
+ * Triggers when EITHER:
+ *   1. Active order count ≥ BUSY_THRESHOLD for ≥ 2 continuous minutes
+ *   2. 3+ new orders arrive within any 10-minute rolling window
+ *
+ * Returns:
+ *   busyMode        — whether busy mode is active
+ *   priorityOrderId — the single order the system recommends acting on next
+ *   missWindowIds   — orders where estimatedReadyAt > deadline
+ */
+export function useBusyMode(orders: KitchenOrder[], externalBusyMode: boolean) {
+  const [sustainedBusy, setSustainedBusy] = useState(false);
+  const [rateBusy, setRateBusy] = useState(false);
+
+  const thresholdExceededSince = useRef<number | null>(null);
+  const arrivalTimestamps = useRef<number[]>([]);
+
+  // Track when threshold was first exceeded for sustained detection
+  useEffect(() => {
+    const active = orders.filter(
+      (o) => o.status !== "complete" && o.status !== "cancelled",
+    ).length;
+
+    if (active >= BUSY_THRESHOLD) {
+      if (thresholdExceededSince.current === null) {
+        thresholdExceededSince.current = Date.now();
+      }
+    } else {
+      thresholdExceededSince.current = null;
+      setSustainedBusy(false);
+    }
+  }, [orders]);
+
+  // Poll to check if sustained threshold has been met
+  useEffect(() => {
+    const timer = setInterval(() => {
+      if (
+        thresholdExceededSince.current !== null &&
+        Date.now() - thresholdExceededSince.current >= SUSTAINED_MS
+      ) {
+        setSustainedBusy(true);
+      }
+    }, 10_000);
+    return () => clearInterval(timer);
+  }, []);
+
+  // Track arrival rate — record when new orders appear
+  const prevOrderIds = useRef(new Set<number>());
+  useEffect(() => {
+    const now = Date.now();
+    for (const o of orders) {
+      if (!prevOrderIds.current.has(o.orderId)) {
+        arrivalTimestamps.current.push(now);
+      }
+    }
+    prevOrderIds.current = new Set(orders.map((o) => o.orderId));
+
+    // Purge timestamps outside the rolling window
+    arrivalTimestamps.current = arrivalTimestamps.current.filter(
+      (t) => now - t < WINDOW_MS,
+    );
+
+    setRateBusy(arrivalTimestamps.current.length >= ARRIVAL_TRIGGER);
+  }, [orders]);
+
+  const busyMode = externalBusyMode || sustainedBusy || rateBusy;
+
+  const { priorityOrderId, missWindowIds } = useMemo(() => {
+    const actionable = orders.filter(
+      (o) => o.status !== "complete" && o.status !== "cancelled" && o.status !== "ready",
+    );
+
+    const missed = actionable.filter((o) =>
+      willMissWindow(o.estimatedReadyAt, o.deadline, o.status),
+    );
+
+    // Sort by priority:
+    // 1. Won't make window (estimatedReadyAt > deadline)
+    // 2. Closest deadline
+    // 3. Oldest unaccepted
+    const sorted = [...actionable].sort((a, b) => {
+      const aMissed = willMissWindow(a.estimatedReadyAt, a.deadline, a.status);
+      const bMissed = willMissWindow(b.estimatedReadyAt, b.deadline, b.status);
+      if (aMissed !== bMissed) return aMissed ? -1 : 1;
+
+      const aDeadline = new Date(a.deadline).getTime();
+      const bDeadline = new Date(b.deadline).getTime();
+      if (aDeadline !== bDeadline) return aDeadline - bDeadline;
+
+      return new Date(a.archivedAt).getTime() - new Date(b.archivedAt).getTime();
+    });
+
+    return {
+      priorityOrderId: sorted[0]?.orderId ?? null,
+      missWindowIds: missed.map((o) => o.orderId),
+    };
+  }, [orders]);
+
+  return { busyMode, priorityOrderId, missWindowIds };
+}

--- a/kitchen/src/hooks/useCookTimer.ts
+++ b/kitchen/src/hooks/useCookTimer.ts
@@ -1,0 +1,94 @@
+import { useMemo } from "react";
+import type { FullOrder, MenuItem, OrderStatus } from "../types/kitchen";
+
+const DEFAULT_COOK_MS = 480_000; // 8 min fallback
+
+/**
+ * Calculate when an order will be physically ready based on the longest
+ * cook time among its items. Uses reduce to avoid RangeError on large arrays.
+ */
+export function calcEstimatedReady(
+  order: FullOrder,
+  menu: MenuItem[],
+  archivedAt: string,
+): Date {
+  const created = new Date(archivedAt);
+  const maxCookMs = order.items.reduce((max, item) => {
+    const menuItem = menu.find((m) => m.id === item.id);
+    const cookSecs =
+      (menuItem?.primaryCookTime ?? 0) + (menuItem?.secondaryCookTime ?? 0);
+    return Math.max(max, cookSecs * 1_000);
+  }, 0);
+  return new Date(created.getTime() + (maxCookMs || DEFAULT_COOK_MS));
+}
+
+/**
+ * Calculate the customer-facing deadline for an order.
+ * Collection: 15 min (midpoint of 10–20 min window), fixed regardless of busy state.
+ * Delivery:   37 min normal | 60 min when kitchen is busy.
+ */
+export function calcDeadline(
+  orderType: "collection" | "delivery",
+  archivedAt: string,
+  busyMode: boolean,
+): Date {
+  const created = new Date(archivedAt);
+  const mins =
+    orderType === "collection" ? 15 : busyMode ? 60 : 37;
+  return new Date(created.getTime() + mins * 60_000);
+}
+
+/**
+ * Hook: given a single order and the full menu, returns estimated ready time
+ * and deadline as ISO strings. Recomputes only when inputs change.
+ */
+export function useCookTimer(
+  order: FullOrder,
+  archivedAt: string,
+  menu: MenuItem[],
+  busyMode: boolean,
+): { estimatedReadyAt: string; deadline: string } {
+  return useMemo(() => ({
+    estimatedReadyAt: calcEstimatedReady(order, menu, archivedAt).toISOString(),
+    deadline: calcDeadline(order.orderType, archivedAt, busyMode).toISOString(),
+  }), [order, archivedAt, menu, busyMode]);
+}
+
+/**
+ * Returns seconds remaining until the target time (positive = future, negative = overdue).
+ */
+export function secondsUntil(isoTarget: string): number {
+  return Math.round((new Date(isoTarget).getTime() - Date.now()) / 1_000);
+}
+
+/**
+ * Formats a second count as MM:SS. Handles negative (overdue) values.
+ */
+export function formatCountdown(totalSeconds: number): string {
+  const abs = Math.abs(totalSeconds);
+  const m = Math.floor(abs / 60);
+  const s = abs % 60;
+  const str = `${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`;
+  return totalSeconds < 0 ? `-${str}` : str;
+}
+
+/**
+ * Derive the urgency colour for a countdown timer.
+ */
+export function timerColour(secondsRemaining: number): "green" | "amber" | "red" {
+  if (secondsRemaining > 5 * 60) return "green";
+  if (secondsRemaining > 2 * 60) return "amber";
+  return "red";
+}
+
+/**
+ * True when the order cannot physically be ready before the deadline.
+ */
+export function willMissWindow(
+  estimatedReadyAt: string,
+  deadline: string,
+  status: OrderStatus,
+): boolean {
+  if (status === "ready" || status === "complete" || status === "cancelled") return false;
+  return new Date(estimatedReadyAt) > new Date(deadline);
+}

--- a/kitchen/src/hooks/useKitchenSocket.ts
+++ b/kitchen/src/hooks/useKitchenSocket.ts
@@ -1,0 +1,74 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { WS_URL } from "../config";
+import type { KitchenSocketEvent } from "../types/kitchen";
+
+const MIN_DELAY_MS = 1_000;
+const MAX_DELAY_MS = 30_000;
+
+/**
+ * Maintains a WebSocket connection to the POS server.
+ * Reconnects with exponential backoff on disconnect (1s → 30s max).
+ * Delivers parsed events to the provided callback without re-subscribing on every render.
+ */
+export function useKitchenSocket(onEvent: (event: KitchenSocketEvent) => void) {
+  const [connected, setConnected] = useState(false);
+  const onEventRef = useRef(onEvent);
+
+  useEffect(() => {
+    onEventRef.current = onEvent;
+  });
+
+  const connect = useCallback(() => {
+    let ws: WebSocket | null = null;
+    let delay = MIN_DELAY_MS;
+    let unmounted = false;
+    let retryTimer: ReturnType<typeof setTimeout> | null = null;
+
+    function attempt() {
+      ws = new WebSocket(WS_URL);
+
+      ws.onopen = () => {
+        setConnected(true);
+        delay = MIN_DELAY_MS;
+      };
+
+      ws.onmessage = (e: MessageEvent) => {
+        try {
+          const msg = JSON.parse(e.data as string) as KitchenSocketEvent;
+          if (msg.type) onEventRef.current(msg);
+        } catch {
+          // ignore malformed frames
+        }
+      };
+
+      ws.onclose = () => {
+        setConnected(false);
+        if (!unmounted) {
+          retryTimer = setTimeout(() => {
+            delay = Math.min(delay * 2, MAX_DELAY_MS);
+            attempt();
+          }, delay);
+        }
+      };
+
+      ws.onerror = () => {
+        ws?.close();
+      };
+    }
+
+    attempt();
+
+    return () => {
+      unmounted = true;
+      if (retryTimer !== null) clearTimeout(retryTimer);
+      ws?.close();
+    };
+  }, []);
+
+  useEffect(() => {
+    const cleanup = connect();
+    return cleanup;
+  }, [connect]);
+
+  return { connected };
+}

--- a/kitchen/src/hooks/useStationLoad.ts
+++ b/kitchen/src/hooks/useStationLoad.ts
@@ -1,0 +1,59 @@
+import { useMemo } from "react";
+import type { KitchenOrder, MenuItem, StationLoadMap, StationType } from "../types/kitchen";
+import { STATION_CONFIG, TRACKED_STATIONS } from "../types/kitchen";
+
+/**
+ * Derives per-station slot usage from currently cooking orders.
+ *
+ * Rules:
+ * - Only orders with status 'cooking' or 'accepted' occupy stations.
+ * - Item quantity is divided by station portionCapacity to get runs needed.
+ * - Same item ID across multiple concurrent orders batches into shared runs.
+ * - Child items (set meal components) are evaluated independently.
+ */
+export function useStationLoad(
+  orders: KitchenOrder[],
+  menu: MenuItem[],
+): StationLoadMap {
+  return useMemo(() => {
+    // Accumulate: stationId → { totalPortions }
+    const portionsByStation = new Map<StationType, number>();
+
+    const activeOrders = orders.filter(
+      (o) => o.status === "cooking" || o.status === "accepted",
+    );
+
+    for (const kitchenOrder of activeOrders) {
+      for (const item of kitchenOrder.order.items) {
+        const menuItem = menu.find((m) => m.id === item.id);
+        if (!menuItem) continue;
+
+        const qty = item.quantity ?? 1;
+
+        if (menuItem.primaryStation) {
+          const st = menuItem.primaryStation;
+          portionsByStation.set(st, (portionsByStation.get(st) ?? 0) + qty);
+        }
+
+        if (menuItem.secondaryStation) {
+          const st = menuItem.secondaryStation;
+          portionsByStation.set(st, (portionsByStation.get(st) ?? 0) + qty);
+        }
+      }
+    }
+
+    const result: StationLoadMap = {};
+
+    for (const station of TRACKED_STATIONS) {
+      const cfg = STATION_CONFIG[station];
+      const totalPortions = portionsByStation.get(station) ?? 0;
+      const totalSlotUses = Math.ceil(totalPortions / cfg.portionCapacity);
+      const used = Math.min(totalSlotUses, cfg.slots);
+      const queued = Math.max(0, totalSlotUses - cfg.slots);
+
+      result[station] = { used, capacity: cfg.slots, queued };
+    }
+
+    return result;
+  }, [orders, menu]);
+}

--- a/kitchen/src/index.css
+++ b/kitchen/src/index.css
@@ -1,0 +1,118 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+  :root {
+    --radius: 10px;
+  }
+
+  html {
+    font-size: 18px;
+    background: #0a0a0a;
+    color: #f4f4f5;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+
+  body {
+    min-height: 100vh;
+    overflow: hidden;
+  }
+
+  /* Custom scrollbar — subtle, dark-themed */
+  ::-webkit-scrollbar { width: 4px; }
+  ::-webkit-scrollbar-track { background: transparent; }
+  ::-webkit-scrollbar-thumb { background: #2a2a2a; border-radius: 99px; }
+  ::-webkit-scrollbar-thumb:hover { background: #3a3a3a; }
+}
+
+@layer components {
+  .order-card {
+    @apply relative bg-[#111111] rounded-xl border border-[#1e1e1e] overflow-hidden;
+    @apply shadow-card transition-all duration-300;
+    animation: slideUp 0.25s ease-out;
+  }
+
+  .order-card-priority {
+    @apply shadow-card-priority;
+    animation: slideUp 0.25s ease-out, glowAmber 2s ease-in-out infinite alternate;
+  }
+
+  .order-card-urgent {
+    @apply shadow-card-urgent;
+  }
+
+  /* Left status bar */
+  .status-bar {
+    @apply absolute left-0 top-0 bottom-0 w-1 rounded-l-xl;
+  }
+
+  .status-bar-new      { @apply bg-kitchen-new; }
+  .status-bar-accepted { @apply bg-kitchen-accepted; }
+  .status-bar-cooking  { @apply bg-kitchen-cooking; }
+  .status-bar-ready    { @apply bg-kitchen-ready; }
+
+  /* Action buttons */
+  .action-btn {
+    @apply w-full py-4 rounded-lg font-bold tracking-widest uppercase text-lg
+           transition-all duration-150 active:scale-[0.98] cursor-pointer;
+  }
+
+  .action-btn-new      { @apply bg-kitchen-new/90 hover:bg-kitchen-new text-white; }
+  .action-btn-accepted { @apply bg-kitchen-accepted/90 hover:bg-kitchen-accepted text-black; }
+  .action-btn-cooking  { @apply bg-kitchen-cooking/90 hover:bg-kitchen-cooking text-white; }
+  .action-btn-ready    { @apply bg-kitchen-ready/90 hover:bg-kitchen-ready text-white; }
+  .action-btn-priority {
+    @apply bg-white text-black hover:bg-amber-50 text-xl py-5;
+  }
+
+  /* Chinese text */
+  .zh {
+    font-family: "Noto Sans SC", "PingFang SC", "Microsoft YaHei", sans-serif;
+  }
+
+  /* Modifier chip */
+  .modifier-chip {
+    @apply inline-flex items-center gap-1 text-amber-400 font-bold text-sm;
+  }
+
+  /* Station pip */
+  .station-pip {
+    @apply flex flex-col items-center gap-1 px-3 py-2 rounded-lg transition-colors duration-300;
+  }
+
+  /* Column */
+  .kanban-col {
+    @apply flex flex-col flex-1 min-w-0 min-h-0 bg-[#0c0c0c] rounded-xl border border-[#181818];
+  }
+
+  .kanban-col-header {
+    @apply flex items-center justify-between px-4 py-3 border-b border-[#1a1a1a] shrink-0;
+  }
+}
+
+@layer utilities {
+  .text-balance { text-wrap: balance; }
+  .font-chinese {
+    font-family: "Noto Sans SC", "PingFang SC", "Microsoft YaHei", sans-serif;
+  }
+}
+
+/* Glow animation for priority card */
+@keyframes glowAmber {
+  0%   { box-shadow: 0 0 0 2px #f59e0b, 0 0 12px 2px rgba(245,158,11,0.25); }
+  100% { box-shadow: 0 0 0 2px #f59e0b, 0 0 28px 6px rgba(245,158,11,0.55); }
+}
+
+@keyframes slideUp {
+  from { opacity: 0; transform: translateY(10px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes pulseRed {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0.5; }
+}
+
+.animate-pulse-red { animation: pulseRed 1.2s ease-in-out infinite; }

--- a/kitchen/src/main.tsx
+++ b/kitchen/src/main.tsx
@@ -1,0 +1,13 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import "./index.css";
+import App from "./App";
+
+const root = document.getElementById("root");
+if (!root) throw new Error("Root element not found");
+
+createRoot(root).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/kitchen/src/types/kitchen.ts
+++ b/kitchen/src/types/kitchen.ts
@@ -1,0 +1,186 @@
+/**
+ * kitchen/src/types/kitchen.ts
+ *
+ * All types used by the kitchen screen.
+ * Intentionally self-contained — does not import from the POS client.
+ */
+
+// ---------------------------------------------------------------------------
+// Stations
+// ---------------------------------------------------------------------------
+
+export type StationType =
+  | "dark_fryer"
+  | "light_fryer"
+  | "oil_wok"
+  | "wet_wok"
+  | "noodle_machine"
+  | "noodle_machine_spicy"
+  | "microwave"
+  | "boiler"
+  | "sauce";
+
+export interface StationRequirement {
+  station: StationType;
+  durationSeconds: number;
+}
+
+export interface StationConfig {
+  slots: number;
+  portionCapacity: number;
+}
+
+export const STATION_CONFIG: Record<StationType, StationConfig> = {
+  dark_fryer:           { slots: 1, portionCapacity: 5 },
+  light_fryer:          { slots: 1, portionCapacity: 5 },
+  oil_wok:              { slots: 2, portionCapacity: 2 },
+  wet_wok:              { slots: 2, portionCapacity: 1 },
+  noodle_machine:       { slots: 2, portionCapacity: 1 },
+  noodle_machine_spicy: { slots: 1, portionCapacity: 1 },
+  microwave:            { slots: 1, portionCapacity: 3 },
+  boiler:               { slots: 1, portionCapacity: 4 },
+  sauce:                { slots: 1, portionCapacity: 99 },
+};
+
+// Stations shown on the load panel — sauce and boiler excluded
+// (sauce is never a bottleneck; boiler is shown as a static always-on indicator)
+export const TRACKED_STATIONS: StationType[] = [
+  "dark_fryer",
+  "light_fryer",
+  "oil_wok",
+  "wet_wok",
+  "noodle_machine",
+  "noodle_machine_spicy",
+  "microwave",
+];
+
+export const STATION_LABELS: Record<StationType, string> = {
+  dark_fryer:           "DARK FRY",
+  light_fryer:          "LIGHT FRY",
+  oil_wok:              "OIL WOKS",
+  wet_wok:              "WET WOKS",
+  noodle_machine:       "NOODLE",
+  noodle_machine_spicy: "SPICY NDL",
+  microwave:            "MICROWAVE",
+  boiler:               "BOILER",
+  sauce:                "SAUCE",
+};
+
+// ---------------------------------------------------------------------------
+// Order types (subset of FullOrder from the POS client)
+// ---------------------------------------------------------------------------
+
+export interface OrderModifier {
+  command?: string;
+  ingredient?: { name?: string; zh?: string };
+  name?: string;
+  zh?: string;
+}
+
+export interface OrderItem {
+  uniqueId: string;
+  id: string;
+  name: string;
+  zhName?: string;
+  price: number;
+  finalPrice?: number;
+  quantity: number;
+  hidePrice?: boolean;
+  hideQuantity?: boolean;
+  isSwapped?: boolean;
+  modifiers?: Array<string | OrderModifier>;
+  parentId?: string;
+  isFoc?: boolean;
+  isIncluded?: boolean;
+}
+
+export interface CustomerInfo {
+  name?: string;
+  phone?: string;
+  address?: string;
+  houseNumber?: string;
+  street?: string;
+  town?: string;
+  postcode?: string;
+  deliveryInstructions?: string;
+  deliveryTime?: string;
+  latitude?: number | null;
+  longitude?: number | null;
+  distance?: number | null;  // miles from store
+}
+
+export interface FullOrder {
+  items: OrderItem[];
+  orderType: "collection" | "delivery";
+  customerInfo?: CustomerInfo;
+  payment: { method: string; amount: number };
+  total: number;
+  notes?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Menu
+// ---------------------------------------------------------------------------
+
+export interface MenuItem {
+  id: string;
+  name: { en: string; zh: string };
+  price?: number;
+  primaryCategory?: string;
+  /** Seconds at the primary station. */
+  primaryCookTime?: number;
+  primaryStation?: StationType;
+  /** Seconds at the secondary station (sequential after primary). */
+  secondaryCookTime?: number;
+  secondaryStation?: StationType;
+  portionCapacity?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Kitchen domain
+// ---------------------------------------------------------------------------
+
+export type OrderStatus =
+  | "new"
+  | "accepted"
+  | "cooking"
+  | "ready"
+  | "complete"
+  | "cancelled";
+
+export interface KitchenOrder {
+  orderId: number;
+  order: FullOrder;
+  status: OrderStatus;
+  archivedAt: string;
+  estimatedReadyAt: string; // calculated client-side from cookTimeSeconds
+  actualReadyAt?: string;   // set when status → 'ready'
+  deadline: string;         // customer expectation window — drives priority
+}
+
+export interface QueueSummary {
+  total: number;
+  byStatus: Partial<Record<OrderStatus, number>>;
+  busyMode: boolean;
+  urgentCount: number;
+  willMissWindow: number;
+}
+
+export interface StationLoad {
+  used: number;     // slot-uses currently occupied
+  capacity: number; // total slots
+  queued: number;   // items waiting because station is full
+}
+
+export type StationLoadMap = Partial<Record<StationType, StationLoad>>;
+
+// ---------------------------------------------------------------------------
+// WebSocket events
+// ---------------------------------------------------------------------------
+
+export type KitchenSocketEvent =
+  | { type: "order_created";       payload: { orderId: number; order: FullOrder; archivedAt: string; status: OrderStatus } }
+  | { type: "order_status_changed"; payload: { orderId: number; previousStatus: OrderStatus; status: OrderStatus; updatedAt: string } }
+  | { type: "order_cancelled";      payload: { orderId: number } }
+  | { type: "order_eta_updated";    payload: { orderId: number; estimatedReadyAt: string } }
+  | { type: "incoming_call";        payload: unknown }; // passthrough — kitchen ignores this

--- a/kitchen/tailwind.config.ts
+++ b/kitchen/tailwind.config.ts
@@ -1,0 +1,53 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: ["./index.html", "./src/**/*.{ts,tsx}"],
+  theme: {
+    extend: {
+      fontFamily: {
+        sans: ["Outfit", "ui-sans-serif", "system-ui", "sans-serif"],
+        mono: ["JetBrains Mono", "ui-monospace", "Consolas", "monospace"],
+        chinese: ["Noto Sans SC", "PingFang SC", "Microsoft YaHei", "sans-serif"],
+      },
+      colors: {
+        surface: {
+          DEFAULT: "#111111",
+          raised: "#161616",
+          border: "#1e1e1e",
+          subtle: "#0d0d0d",
+        },
+        kitchen: {
+          new: "#22c55e",
+          accepted: "#f59e0b",
+          cooking: "#3b82f6",
+          ready: "#71717a",
+          complete: "#3f3f46",
+          cancelled: "#ef4444",
+        },
+      },
+      animation: {
+        "pulse-slow": "pulse 2.5s cubic-bezier(0.4, 0, 0.6, 1) infinite",
+        "glow-amber": "glowAmber 2s ease-in-out infinite alternate",
+        "slide-up": "slideUp 0.3s ease-out",
+      },
+      keyframes: {
+        glowAmber: {
+          "0%": { boxShadow: "0 0 8px 0 rgba(245, 158, 11, 0.3)" },
+          "100%": { boxShadow: "0 0 24px 4px rgba(245, 158, 11, 0.6)" },
+        },
+        slideUp: {
+          "0%": { opacity: "0", transform: "translateY(8px)" },
+          "100%": { opacity: "1", transform: "translateY(0)" },
+        },
+      },
+      boxShadow: {
+        card: "0 2px 8px rgba(0,0,0,0.4), 0 0 0 1px rgba(255,255,255,0.04)",
+        "card-priority": "0 0 0 2px #f59e0b, 0 0 24px 4px rgba(245,158,11,0.35)",
+        "card-urgent": "0 0 0 2px #ef4444, 0 0 20px 2px rgba(239,68,68,0.3)",
+      },
+    },
+  },
+  plugins: [],
+};
+
+export default config;

--- a/kitchen/tsconfig.app.json
+++ b/kitchen/tsconfig.app.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+    "target": "ES2023",
+    "useDefineForClassFields": true,
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "types": ["vite/client"],
+    "skipLibCheck": true,
+
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["src"]
+}

--- a/kitchen/tsconfig.json
+++ b/kitchen/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "files": [],
+  "references": [{ "path": "./tsconfig.app.json" }, { "path": "./tsconfig.node.json" }]
+}

--- a/kitchen/tsconfig.node.json
+++ b/kitchen/tsconfig.node.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
+    "target": "ES2023",
+    "lib": ["ES2023"],
+    "module": "ESNext",
+    "types": ["node"],
+    "skipLibCheck": true,
+
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/kitchen/vite.config.ts
+++ b/kitchen/vite.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    proxy: {
+      "/api": "http://localhost:4000",
+      "/ws": { target: "ws://localhost:4000", ws: true },
+    },
+  },
+});

--- a/server/src/api/router.js
+++ b/server/src/api/router.js
@@ -17,6 +17,7 @@ import { customersRouter } from "../domains/customers/customers.router.js";
 import { addressesRouter } from "../domains/addresses/addresses.router.js";
 import { telemetryRouter } from "../domains/telemetry/telemetry.router.js";
 import { callsRouter } from "../domains/calls/calls.router.js";
+import { menuRouter } from "../domains/menu/menu.router.js";
 import { errorHandler as globalErrorHandler } from "../shared/middleware/errorHandler.js";
 
 export const apiRouter = Router();
@@ -30,6 +31,7 @@ apiRouter.use("/customers", customersRouter);
 apiRouter.use("/addresses", addressesRouter);
 apiRouter.use("/telemetry", telemetryRouter);
 apiRouter.use("/calls", callsRouter);
+apiRouter.use("/menu", menuRouter);
 
 // ---------------------------------------------------------------------------
 // 404 handler - unknown API route

--- a/server/src/config/index.js
+++ b/server/src/config/index.js
@@ -202,5 +202,12 @@ export const config = {
   ws: {
     heartbeatInterval: env.WS_HEARTBEAT_MS,
   },
+
+  kitchen: {
+    // Number of active orders that triggers busy mode on the kitchen screen.
+    // Tune this after observing real usage — 4 is a conservative starting point.
+    busyThreshold: 4,
+  },
+
   logLevel: env.LOG_LEVEL,
 };

--- a/server/src/domains/menu/menu.router.js
+++ b/server/src/domains/menu/menu.router.js
@@ -1,0 +1,176 @@
+/**
+ * domains/menu/menu.router.js
+ *
+ * GET    /api/menu       — return the full menu array
+ * POST   /api/menu       — create a new menu item
+ * PUT    /api/menu/:id   — update kitchen fields for one item
+ * DELETE /api/menu/:id   — remove an item
+ */
+
+import { Router } from "express";
+import { z } from "zod";
+import { readFile, writeFile } from "fs/promises";
+import path from "path";
+import { fileURLToPath } from "url";
+import { sendValidationError } from "../../shared/middleware/sendValidationError.js";
+import { logger } from "../../infrastructure/logger.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const MENU_PATH = path.resolve(__dirname, "../../../../client/src/assets/menu.json");
+
+export const menuRouter = Router();
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function readMenu() {
+  const raw = await readFile(MENU_PATH, "utf-8");
+  return JSON.parse(raw);
+}
+
+async function writeMenu(data) {
+  await writeFile(MENU_PATH, JSON.stringify(data, null, 2) + "\n", "utf-8");
+}
+
+// ---------------------------------------------------------------------------
+// Validation schemas
+// ---------------------------------------------------------------------------
+
+const VALID_STATIONS = /** @type {const} */ ([
+  "dark_fryer",
+  "light_fryer",
+  "oil_wok",
+  "wet_wok",
+  "noodle_machine",
+  "noodle_machine_spicy",
+  "microwave",
+  "boiler",
+  "sauce",
+]);
+
+const kitchenFieldsSchema = z.object({
+  primaryStation:   z.enum(VALID_STATIONS).nullable().optional(),
+  primaryCookTime:  z.number().int().positive().nullable().optional(),
+  secondaryStation: z.enum(VALID_STATIONS).nullable().optional(),
+  secondaryCookTime: z.number().int().positive().nullable().optional(),
+  portionCapacity:  z.number().int().positive().nullable().optional(),
+});
+
+const createSchema = z.object({
+  id:              z.string().min(1).max(20),
+  nameEn:          z.string().min(1),
+  nameZh:          z.string().optional().default(""),
+  price:           z.number().nonnegative().optional(),
+  primaryCategory: z.string().optional().default(""),
+}).merge(kitchenFieldsSchema);
+
+// ---------------------------------------------------------------------------
+// Routes
+// ---------------------------------------------------------------------------
+
+menuRouter.get("/", async (_req, res, next) => {
+  try {
+    res.json(await readMenu());
+  } catch (err) {
+    next(err);
+  }
+});
+
+menuRouter.post("/", async (req, res, next) => {
+  try {
+    const parsed = createSchema.safeParse(req.body);
+    if (!parsed.success) return sendValidationError(res, parsed.error);
+
+    const menu = await readMenu();
+    const { id, nameEn, nameZh, price, primaryCategory, ...kitchen } = parsed.data;
+
+    if (menu.some((item) => item.id === id)) {
+      return res.status(409).json({
+        error: { code: "CONFLICT", message: `Item ID '${id}' already exists` },
+      });
+    }
+
+    const newItem = {
+      id,
+      name: { en: nameEn, zh: nameZh ?? "" },
+      ...(price !== undefined ? { price } : {}),
+      ...(primaryCategory ? { primaryCategory } : {}),
+      ...Object.fromEntries(
+        Object.entries(kitchen).filter(([, v]) => v !== null && v !== undefined),
+      ),
+    };
+
+    menu.push(newItem);
+    await writeMenu(menu);
+    logger.info("Menu item created", { id });
+    res.status(201).json(newItem);
+  } catch (err) {
+    next(err);
+  }
+});
+
+menuRouter.put("/:id", async (req, res, next) => {
+  try {
+    const parsed = kitchenFieldsSchema.extend({
+      nameEn: z.string().min(1).optional(),
+      nameZh: z.string().optional(),
+      price:  z.number().nonnegative().nullable().optional(),
+      primaryCategory: z.string().optional(),
+    }).safeParse(req.body);
+
+    if (!parsed.success) return sendValidationError(res, parsed.error);
+
+    const menu = await readMenu();
+    const idx = menu.findIndex((item) => item.id === req.params.id);
+
+    if (idx === -1) {
+      return res.status(404).json({
+        error: { code: "NOT_FOUND", message: `Menu item '${req.params.id}' not found` },
+      });
+    }
+
+    const { nameEn, nameZh, price, primaryCategory, ...kitchen } = parsed.data;
+
+    if (nameEn !== undefined) menu[idx].name = { ...menu[idx].name, en: nameEn };
+    if (nameZh !== undefined) menu[idx].name = { ...menu[idx].name, zh: nameZh };
+    if (price !== undefined) {
+      price === null ? delete menu[idx].price : (menu[idx].price = price);
+    }
+    if (primaryCategory !== undefined) menu[idx].primaryCategory = primaryCategory;
+
+    for (const [key, val] of Object.entries(kitchen)) {
+      if (val === null) {
+        delete menu[idx][key];
+      } else if (val !== undefined) {
+        menu[idx][key] = val;
+      }
+    }
+
+    await writeMenu(menu);
+    logger.info("Menu item updated", { id: req.params.id });
+    res.json(menu[idx]);
+  } catch (err) {
+    next(err);
+  }
+});
+
+menuRouter.delete("/:id", async (req, res, next) => {
+  try {
+    const menu = await readMenu();
+    const idx = menu.findIndex((item) => item.id === req.params.id);
+
+    if (idx === -1) {
+      return res.status(404).json({
+        error: { code: "NOT_FOUND", message: `Menu item '${req.params.id}' not found` },
+      });
+    }
+
+    menu.splice(idx, 1);
+    await writeMenu(menu);
+    logger.info("Menu item deleted", { id: req.params.id });
+    res.status(204).end();
+  } catch (err) {
+    next(err);
+  }
+});

--- a/server/src/domains/orders/orders.repo.js
+++ b/server/src/domains/orders/orders.repo.js
@@ -24,12 +24,18 @@ import { AppError } from "../../shared/errors.js";
 const stmts = {
   insert: null,
   findById: null,
+  findByClientOrderId: null,
   findAll: null,
   findByDate: null,
   delete: null,
   deleteByDate: null,
   deleteBeforeDate: null,
   findByCustomerPhone: null,
+  // kitchen screen
+  initStatus: null,
+  setStatus: null,
+  getActive: null,
+  getPrevStatus: null,
 };
 
 /**
@@ -39,8 +45,9 @@ const stmts = {
 function getStmts() {
   const db = getDb();
   if (!stmts.insert) {
-    stmts.insert = db.prepare("INSERT INTO orders (data, archived_at) VALUES (?, ?)");
+    stmts.insert = db.prepare("INSERT INTO orders (data, archived_at, client_order_id) VALUES (?, ?, ?)");
     stmts.findById = db.prepare("SELECT * FROM orders WHERE id = ?");
+    stmts.findByClientOrderId = db.prepare("SELECT * FROM orders WHERE client_order_id = ?");
     stmts.findAll = db.prepare("SELECT * FROM orders ORDER BY archived_at DESC LIMIT 500");
     stmts.findByDate = db.prepare(
       "SELECT * FROM orders WHERE archived_at LIKE ? ORDER BY archived_at DESC",
@@ -55,6 +62,29 @@ function getStmts() {
         AND json_extract(data, '$.customerInfo.phone') = ?
       ORDER BY archived_at DESC
     `);
+    // kitchen screen statements
+    stmts.initStatus = db.prepare(
+      "INSERT INTO order_status (order_id, status, estimated_ready_at) VALUES (?, ?, ?)",
+    );
+    stmts.setStatus = db.prepare(`
+      UPDATE order_status
+      SET status     = $status,
+          updated_at = datetime('now'),
+          updated_by = $updatedBy,
+          actual_ready_at = CASE WHEN $status = 'ready' THEN datetime('now') ELSE actual_ready_at END
+      WHERE order_id = $orderId
+    `);
+    stmts.getActive = db.prepare(`
+      SELECT o.id, o.data, o.archived_at,
+             s.status, s.updated_at, s.estimated_ready_at, s.actual_ready_at
+      FROM orders o
+      JOIN order_status s ON s.order_id = o.id
+      WHERE s.status NOT IN ('complete', 'cancelled')
+      ORDER BY o.archived_at ASC
+    `);
+    stmts.getPrevStatus = db.prepare(
+      "SELECT status FROM order_status WHERE order_id = ?",
+    );
   }
   return stmts;
 }
@@ -97,18 +127,23 @@ function rowToOrder(row) {
  * @param {{ data: object, archivedAt?: string }} orderData
  * @returns {{ id: number, data: object, archivedAt: string }}
  */
-export function createOrder({ data, archivedAt }) {
-  const { insert } = getStmts();
+export function createOrder({ data, archivedAt, clientOrderId }) {
+  const { insert, findByClientOrderId } = getStmts();
   const at = archivedAt ?? new Date().toISOString();
 
-  // Use lastInsertRowid — never MAX(id)+1 — fixing the old race condition
-  const result = insert.run(JSON.stringify(data), at);
-
-  return {
-    id: Number(result.lastInsertRowid),
-    data,
-    archivedAt: at,
-  };
+  try {
+    // Use lastInsertRowid — never MAX(id)+1 — fixing the old race condition
+    const result = insert.run(JSON.stringify(data), at, clientOrderId ?? null);
+    return { id: Number(result.lastInsertRowid), data, archivedAt: at };
+  } catch (err) {
+    // A duplicate clientOrderId means the client is retrying a request we already stored.
+    // Return the original row so the response is idempotent.
+    if (err.code === "SQLITE_CONSTRAINT_UNIQUE" && clientOrderId) {
+      const existing = findByClientOrderId.get(clientOrderId);
+      if (existing) return rowToOrder(existing);
+    }
+    throw err;
+  }
 }
 
 /**
@@ -259,4 +294,81 @@ export function findOrdersByPhone(phone) {
       }
     })
     .filter(Boolean);
+}
+
+// ---------------------------------------------------------------------------
+// Kitchen screen — order_status table
+// ---------------------------------------------------------------------------
+
+/**
+ * Insert an initial status row for a newly archived order.
+ *
+ * @param {number} orderId
+ * @param {'new'|'cooking'} initialStatus - 'cooking' for auto-started collection orders
+ * @param {string|null} estimatedReadyAt  - ISO string, null in Phase 1 (calculated client-side)
+ */
+export function initOrderStatus(orderId, initialStatus = "new", estimatedReadyAt = null) {
+  const { initStatus } = getStmts();
+  initStatus.run(orderId, initialStatus, estimatedReadyAt);
+}
+
+/**
+ * Transition an order to a new status.
+ * Automatically sets actual_ready_at when status becomes 'ready'.
+ *
+ * @param {number} orderId
+ * @param {string} status
+ * @param {string} [updatedBy]
+ */
+export function setOrderStatus(orderId, status, updatedBy = "kitchen") {
+  const { setStatus } = getStmts();
+  setStatus.run({ status, updatedBy, orderId });
+}
+
+/**
+ * Return all active orders (status not 'complete' or 'cancelled'), oldest first.
+ *
+ * @returns {Array<{
+ *   orderId: number,
+ *   order: object,
+ *   status: string,
+ *   archivedAt: string,
+ *   updatedAt: string,
+ *   estimatedReadyAt: string|null,
+ *   actualReadyAt: string|null,
+ * }>}
+ */
+export function getActiveOrders() {
+  const { getActive } = getStmts();
+  const rows = getActive.all();
+  return rows.map((row) => {
+    let order;
+    try {
+      order = JSON.parse(row.data);
+    } catch {
+      order = {};
+    }
+    return {
+      orderId: row.id,
+      order,
+      status: row.status,
+      archivedAt: row.archived_at,
+      updatedAt: row.updated_at,
+      estimatedReadyAt: row.estimated_ready_at ?? null,
+      actualReadyAt: row.actual_ready_at ?? null,
+    };
+  });
+}
+
+/**
+ * Return the current status of an order before updating it.
+ * Used to capture previousStatus for the WS event.
+ *
+ * @param {number} orderId
+ * @returns {string|null}
+ */
+export function getPreviousStatus(orderId) {
+  const { getPrevStatus } = getStmts();
+  const row = getPrevStatus.get(orderId);
+  return row?.status ?? null;
 }

--- a/server/src/domains/orders/orders.router.js
+++ b/server/src/domains/orders/orders.router.js
@@ -15,6 +15,7 @@ import { z } from "zod";
 import * as service from "./orders.service.js";
 import { sendValidationError } from "../../shared/middleware/sendValidationError.js";
 import { requireAdminAuth } from "../../shared/middleware/requireAdminAuth.js";
+import { broadcast } from "../../api/websocket.js";
 
 export const ordersRouter = Router();
 
@@ -151,6 +152,7 @@ const printableOrderSchema = z
 const printOrderRequestSchema = z.object({
   order: printableOrderSchema,
   payment: paymentSchema.optional(),
+  clientOrderId: z.string().uuid().optional(),
 });
 
 // ---------------------------------------------------------------------------
@@ -203,7 +205,7 @@ ordersRouter.post("/print", async (req, res, next) => {
     return sendValidationError(res, details);
   }
 
-  const { order, payment } = parsed.data;
+  const { order, payment, clientOrderId } = parsed.data;
   const orderData = { ...order, payment: payment ?? order.payment };
 
   if (!orderData.payment) {
@@ -211,8 +213,60 @@ ordersRouter.post("/print", async (req, res, next) => {
   }
 
   try {
-    const result = await service.printAndArchiveOrder(orderData);
-    return res.status(200).json(result);
+    const result = await service.printAndArchiveOrder(orderData, clientOrderId);
+    broadcast("order_created", {
+      orderId: result.orderId,
+      order: orderData,
+      archivedAt: result.archivedAt,
+      status: result.status,
+    });
+    return res.status(200).json({ orderId: result.orderId, printed: result.printed });
+  } catch (err) {
+    next(err);
+  }
+});
+
+/**
+ * GET /api/orders/active
+ * Return all active (non-complete, non-cancelled) orders for the kitchen screen.
+ * Registered before /:id so 'active' is not swallowed as an ID param.
+ */
+ordersRouter.get("/active", (req, res, next) => {
+  try {
+    const orders = service.getActiveOrders();
+    return res.json({ orders });
+  } catch (err) {
+    next(err);
+  }
+});
+
+/**
+ * PATCH /api/orders/:id/status
+ * Transition a kitchen order to a new status.
+ * Broadcasts order_status_changed to all WS clients.
+ */
+const kitchenStatusSchema = z.object({
+  status: z.enum(["new", "accepted", "cooking", "ready", "complete", "cancelled"]),
+  updatedBy: z.string().optional(),
+});
+
+ordersRouter.patch("/:id/status", (req, res, next) => {
+  const id = parseId(req.params.id);
+  if (!id) {
+    return sendValidationError(res, {}, "Order id must be a positive integer");
+  }
+
+  const parsed = kitchenStatusSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return sendValidationError(res, parsed.error.flatten().fieldErrors);
+  }
+
+  const { status, updatedBy } = parsed.data;
+
+  try {
+    const { previousStatus, updatedAt } = service.setKitchenStatus(id, status, updatedBy);
+    broadcast("order_status_changed", { orderId: id, previousStatus, status, updatedAt });
+    return res.json({ orderId: id, status, updatedAt });
   } catch (err) {
     next(err);
   }

--- a/server/src/domains/orders/orders.service.js
+++ b/server/src/domains/orders/orders.service.js
@@ -95,7 +95,7 @@ function validateOrder(order) {
  * @returns {{ id: number, data: object, archivedAt: string }}
  * @throws {ValidationError} if the order fails business rules
  */
-export function createOrder(orderData) {
+export function createOrder(orderData, clientOrderId) {
   validateOrder(orderData);
 
   // Auto-sync the customer profile so that Name/Address aren't missing in future searches/exports
@@ -103,23 +103,37 @@ export function createOrder(orderData) {
     customers.syncCustomerFromOrder(orderData.customerInfo);
   }
 
-  return repo.createOrder({ data: orderData });
+  return repo.createOrder({ data: orderData, clientOrderId });
 }
 
 /**
  * Archive an order and attempt to print it.
+ * Also initialises the kitchen workflow status row.
  *
  * Saving the order is the critical operation; printing is best-effort (mirrors legacy behaviour).
  *
  * @param {object} orderData - Raw order payload from the route handler
- * @returns {Promise<{ orderId: number, printed: boolean }>}
+ * @param {string} [clientOrderId]
+ * @returns {Promise<{ orderId: number, printed: boolean, status: string, archivedAt: string }>}
  */
-export async function printAndArchiveOrder(orderData) {
-  const archived = createOrder(orderData);
+export async function printAndArchiveOrder(orderData, clientOrderId) {
+  const archived = createOrder(orderData, clientOrderId);
 
+  // Determine initial kitchen status:
+  //  - Collection + empty kitchen → auto-start cooking (no one needs to accept it)
+  //  - Everything else → 'new' (staff decide, or hold delivery for batching)
+  const activeOrders = repo.getActiveOrders();
+  const initialStatus =
+    orderData.orderType === "collection" && activeOrders.length === 0
+      ? "cooking"
+      : "new";
+
+  repo.initOrderStatus(archived.id, initialStatus, null);
+
+  let printed = false;
   try {
     const result = await printReceipt(archived);
-    return { orderId: archived.id, printed: result.printed === true };
+    printed = result.printed === true;
   } catch (err) {
     const isHardwareError = err instanceof HardwareError;
     logger.error("Order saved but printing failed", {
@@ -128,8 +142,52 @@ export async function printAndArchiveOrder(orderData) {
       error: err?.message ?? String(err),
       ...(isHardwareError ? { details: err.details } : {}),
     });
-    return { orderId: archived.id, printed: false };
   }
+
+  return { orderId: archived.id, printed, status: initialStatus, archivedAt: archived.archivedAt };
+}
+
+// ---------------------------------------------------------------------------
+// Kitchen screen
+// ---------------------------------------------------------------------------
+
+/**
+ * Return all active (non-complete, non-cancelled) orders for the kitchen screen.
+ *
+ * @returns {Array<object>}
+ */
+export function getActiveOrders() {
+  return repo.getActiveOrders();
+}
+
+const VALID_STATUSES = ["new", "accepted", "cooking", "ready", "complete", "cancelled"];
+
+/**
+ * Transition an order to a new kitchen status.
+ * Returns the previous status so the caller can broadcast the change.
+ *
+ * @param {number} id
+ * @param {string} status
+ * @param {string} [updatedBy]
+ * @returns {{ previousStatus: string|null, updatedAt: string }}
+ * @throws {ValidationError} if status is not one of the 6 valid values
+ * @throws {NotFoundError} if the order has no status row
+ */
+export function setKitchenStatus(id, status, updatedBy = "kitchen") {
+  if (!VALID_STATUSES.includes(status)) {
+    throw new ValidationError(
+      `Invalid status '${status}'. Must be one of: ${VALID_STATUSES.join(", ")}`,
+      { field: "status", received: status },
+    );
+  }
+
+  const previousStatus = repo.getPreviousStatus(id);
+  if (previousStatus === null) {
+    throw new NotFoundError(`No kitchen status found for order ${id}`, { id });
+  }
+
+  repo.setOrderStatus(id, status, updatedBy);
+  return { previousStatus, updatedAt: new Date().toISOString() };
 }
 
 /**

--- a/server/src/domains/tapiService/tapiService.service.js
+++ b/server/src/domains/tapiService/tapiService.service.js
@@ -103,8 +103,12 @@ export async function handleDisconnected(callId, phone, durationSeconds) {
     return;
   }
 
-  const endedAt  = new Date();
+  const endedAt   = new Date();
   const startedAt = call?.startedAt ?? new Date(endedAt.getTime() - durationSeconds * 1_000);
+  // Derive duration from our own timestamps so it is consistent with call_started_at/call_ended_at.
+  // (call_started_at reflects CONNECTED time if the call was answered; the bridge's durationSeconds
+  // counts from OFFERING, which would produce an inconsistent value.)
+  const resolvedDuration = Math.round((endedAt.getTime() - startedAt.getTime()) / 1_000);
 
   try {
     const db = getDb();
@@ -125,13 +129,13 @@ export async function handleDisconnected(callId, phone, durationSeconds) {
       resolvedPhone,
       startedAt.toISOString(),
       endedAt.toISOString(),
-      durationSeconds,
+      resolvedDuration,
       customerName,
     );
 
     logger.info("Call logged", {
       phone: resolvedPhone,
-      durationSeconds,
+      durationSeconds: resolvedDuration,
       customerName,
     });
   } catch (err) {

--- a/server/src/infrastructure/migrations/003_orders_customer_phone_index.sql
+++ b/server/src/infrastructure/migrations/003_orders_customer_phone_index.sql
@@ -1,4 +1,7 @@
 -- Migration: 003_orders_customer_phone_index.sql
+-- TODO: rename to 004_orders_customer_phone_index.sql — this file shares the 003_ prefix with
+-- 003_call_logs.sql. The runner tracks by full filename so there is no runtime crash, but the
+-- numbering is wrong and will cause confusion when the next migration is added.
 -- Adds an expression index to speed up GDPR export/erasure phone lookups
 -- inside the orders.data JSON blob.
 

--- a/server/src/infrastructure/migrations/004_orders_client_order_id.sql
+++ b/server/src/infrastructure/migrations/004_orders_client_order_id.sql
@@ -1,0 +1,13 @@
+-- Migration: 004_orders_client_order_id
+-- Adds a client-generated idempotency key to orders.
+-- Allows the server to detect and deduplicate retry submissions from the client
+-- print queue without creating duplicate order rows.
+--
+-- NULL is allowed (legacy orders have no clientOrderId) so the unique index
+-- uses a partial WHERE clause to exclude NULLs from the uniqueness check.
+
+ALTER TABLE orders ADD COLUMN client_order_id TEXT;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_orders_client_order_id
+  ON orders (client_order_id)
+  WHERE client_order_id IS NOT NULL;

--- a/server/src/infrastructure/migrations/005_order_status.sql
+++ b/server/src/infrastructure/migrations/005_order_status.sql
@@ -1,0 +1,20 @@
+-- Migration: 005_order_status
+-- Adds a separate workflow status table for the kitchen screen.
+--
+-- Design decisions:
+--  - Kept separate from orders.data so the archive blob stays immutable.
+--  - estimated_ready_at is set on creation (null for Phase 1, calculated client-side).
+--  - actual_ready_at is set automatically by setOrderStatus when status → 'ready'.
+--  - FK to orders(id) enforced — SQLite has foreign_keys = ON at runtime.
+
+CREATE TABLE IF NOT EXISTS order_status (
+  order_id            INTEGER PRIMARY KEY REFERENCES orders(id),
+  status              TEXT NOT NULL DEFAULT 'new',
+  updated_at          TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_by          TEXT NOT NULL DEFAULT 'system',
+  estimated_ready_at  TEXT,
+  actual_ready_at     TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_order_status_status  ON order_status (status);
+CREATE INDEX IF NOT EXISTS idx_order_status_updated ON order_status (updated_at DESC);


### PR DESCRIPTION
Kitchen screen (kitchen/):
- Real-time Kanban board — New / Cooking / Ready columns
- WebSocket connection with exponential backoff reconnect
- Busy mode detection: sustained load (4+ orders, 2 min) or arrival burst (3 in 10 min)
- Priority card ("DO THIS NOW") and won't-make-window warnings
- Station load panel: dark/light fryer, oil/wet wok, noodle machines, microwave
- Countdown timers to deadline, waiting time badges, bilingual item display
- Delivery ETA = estimated ready time + drive time (distance × 3.5 min/mile)
- Batch detection: flags nearby delivery orders still in 'new' status for same-driver runs

Order lifecycle API (server/):
- GET  /api/orders/active — live kitchen queue with status
- PATCH /api/orders/:id/status — advance through new→accepted→cooking→ready→complete
- Migration 005: order_status table backing the kitchen state machine
- Smart init: collection + empty queue auto-advances to cooking
- WS events: order_created, order_status_changed, order_cancelled, order_eta_updated

Menu API (server/):
- GET/POST/PUT/DELETE /api/menu — full CRUD backed by menu.json
- Kitchen fields per item: primaryStation, primaryCookTime, secondaryStation, secondaryCookTime, portionCapacity

Admin menu editor (client/):
- Menu Editor tab in admin panel with per-station cook time inputs
- Add and delete items with full kitchen field support
- Category filter and search

Auth fix (client/):
- Rename VITE_ADMIN_PASSWORD → VITE_ADMIN_API_TOKEN
- Detect token mismatch between old and new env keys
- Better error messages for unconfigured or rate-limited auth

Types (client/ + kitchen/):
- OrderStatus type and extended WebSocketMessage union with four new event types
- CustomerInfo gains latitude, longitude, distance for ETA and batch detection